### PR TITLE
FIX glob pattern in windows

### DIFF
--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -137,7 +137,7 @@ function getFilesToReview(
 
 function findFiles(directory) {
   return {
-    files: glob.sync(directory + '/**/*.elm', {
+    files: glob.sync((directory.startsWith('C:') ? directory.slice(2).replace(/\\/g, '/') : directory) + '/**/*.elm', {
       nocase: true,
       ignore,
       nodir: false

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -138,9 +138,7 @@ function getFilesToReview(
 function findFiles(directory) {
   return {
     files: glob.sync(
-      (directory.startsWith('C:')
-        ? directory.slice(2).replace(/\\/g, '/')
-        : directory) + '/**/*.elm',
+      directory.replace(/.:/, '').replace(/\\/g, '/') + '/**/*.elm',
       {
         nocase: true,
         ignore,

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -137,11 +137,16 @@ function getFilesToReview(
 
 function findFiles(directory) {
   return {
-    files: glob.sync((directory.startsWith('C:') ? directory.slice(2).replace(/\\/g, '/') : directory) + '/**/*.elm', {
-      nocase: true,
-      ignore,
-      nodir: false
-    }),
+    files: glob.sync(
+      (directory.startsWith('C:')
+        ? directory.slice(2).replace(/\\/g, '/')
+        : directory) + '/**/*.elm',
+      {
+        nocase: true,
+        ignore,
+        nodir: false
+      }
+    ),
     directory
   };
 }


### PR DESCRIPTION
Thank you for a great tool🎉

I was happy and tried it right away! 

![image](https://user-images.githubusercontent.com/13114545/66046011-d59cfd00-e55f-11e9-9588-7d51b001878e.png)

there was src/Main.elm...

In windows, ["glob" require only forward-slashes](https://github.com/isaacs/node-glob#windows)

fixed it, then:

![image](https://user-images.githubusercontent.com/13114545/66046177-2ca2d200-e560-11e9-99d5-d5165585900e.png)

Could you fix it like this?
