### PR TITLE
Use --stdin option of elm-format

### DIFF
--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -54,17 +54,12 @@ function askConfirmationToFixWithOptions(options, app) {
     }
 
     if (accepted) {
-      // TODO Format file before saving it.
-      // I could not manage to make this work at the moment
-      //
-      // const file = await formatFileContent(latestChangedFiles)
-      // fs.writeFileSync(file)
       const formattedFiles = filesToFix.map((file) => {
-        fs.writeFileSync(file.path, file.source);
         if (file.path.endsWith('.elm')) {
-          return formatExistingFile(options, file);
+          return formatFileContent(options, file);
         }
 
+        fs.writeFileSync(file.path, file.source);
         return file;
       });
 
@@ -91,13 +86,14 @@ function checkIfAFixConfirmationIsStillExpected(app) {
   });
 }
 
-function formatExistingFile(options, file) {
+function formatFileContent(options, file) {
   if (options.elmFormatPath) {
     const spawnedUsingPathFromArgs = spawn.sync(
       options.elmFormatPath,
-      ['--yes', '--elm-version=0.19', file.path],
+      ['--elm-version=0.19', '--stdin', '--output', file.path],
       {
-        shell: true
+        shell: true,
+        input: file.source
       }
     );
 
@@ -117,8 +113,18 @@ options.elmJsonPath
   } else {
     const spawnedUsingNpx = spawn.sync(
       'npx',
-      ['--no-install', 'elm-format', '--yes', '--elm-version=0.19', file.path],
-      {shell: true}
+      [
+        '--no-install',
+        'elm-format',
+        '--elm-version=0.19',
+        '--stdin',
+        '--output',
+        file.path
+      ],
+      {
+        shell: true,
+        input: file.source
+      }
     );
 
     if (spawnedUsingNpx.status !== 0) {
@@ -140,11 +146,13 @@ options.elmJsonPath
 
       const spawnedUsingGlobal = spawn.sync(
         'elm-format',
-        ['--yes', '--elm-version=0.19', file.path],
+        ['--yes', '--elm-version=0.19', '--stdin', '--output', file.path],
         {
-          shell: true
+          shell: true,
+          input: file.source
         }
       );
+
       if (spawnedUsingGlobal.status !== 0) {
         throw new errorMessage.CustomError(
           /* eslint-disable prettier/prettier */


### PR DESCRIPTION
This saves having to write the file to disk before immediately asking elm-format to load it and change it. This may save a little processing time and should prevent any double hits for other tools watching the files.