### PR TITLE
Make report async

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -2,7 +2,7 @@ const styledMessage = require('./styled-message');
 
 module.exports = report;
 
-function report(options, result) {
+async function report(options, result) {
   if (options.report === 'json') {
     return print(options, jsonReport(result.errors));
   }
@@ -22,22 +22,46 @@ function jsonReport(errors) {
 function print(options, json) {
   if (options.reportOnOneLine) {
     if (json.type === 'review-errors') {
-      json.errors.forEach((errorForFile) => {
-        errorForFile.errors.forEach((error) => {
-          console.log(
-            JSON.stringify({
-              path: errorForFile.path,
-              ...error
+      if (json.errors.length > 0) {
+        return safeConsoleLog(
+          json.errors
+            .map((errorForFile) => {
+              return errorForFile.errors
+                .map((error) => {
+                  return JSON.stringify({
+                    path: errorForFile.path,
+                    ...error
+                  });
+                })
+                .join('\n');
             })
-          );
-        });
-      });
+            .join('\n')
+        );
+      }
     } else {
-      console.log(JSON.stringify(json));
+      return safeConsoleLog(JSON.stringify(json));
     }
   } else {
-    console.log(
+    return safeConsoleLog(
       JSON.stringify(json, null, options.debug || options.forTests ? 2 : 0)
     );
   }
+}
+
+// Printing large outputs to stdout is not recommended because at times
+// console.log is asynchronous and returns before ensuring that the whole
+// output has been printed. Check out these links for more details:
+//
+// - https://nodejs.org/api/process.html#process_process_exit_code
+// - https://github.com/nodejs/node/issues/6456
+// - https://github.com/nodejs/node/issues/19218
+//
+// Using process.stdout.write and passing a function ensures that
+// the whole output has been written.
+function safeConsoleLog(message) {
+  return new Promise((resolve) => {
+    process.stdout.write(message + '\n', () => {
+      resolve();
+    });
+  });
 }

--- a/lib/run-review.js
+++ b/lib/run-review.js
@@ -23,7 +23,7 @@ async function runReview(options, app) {
   });
   Benchmark.end(options, 'review');
 
-  report(options, result);
+  await report(options, result);
 
   return result.success;
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -76,11 +76,12 @@ async function initializeApp(options, elmModulePath, reviewElmJson) {
   autofix.subscribe(options, app);
   if (options.watch) {
     AppState.subscribe(app.ports.reviewReport, (result) => {
-      report(options, result);
-      const shouldReReview = AppState.reviewFinished();
-      if (shouldReReview) {
-        return startReview(options, app);
-      }
+      return report(options, result).then(() => {
+        const shouldReReview = AppState.reviewFinished();
+        if (shouldReReview) {
+          return startReview(options, app);
+        }
+      });
     });
   }
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -42,7 +42,7 @@ function runCommandAndCompareToSnapshot {
         echo -e "\n    \e[31mbut got:\e[0m\n"
         cat "$TMP/$FILE"
         echo -e "\n    \e[31mHere is the difference:\e[0m\n"
-        diff "$TMP/$FILE" "$SNAPSHOTS/$FILE"
+        diff -p "$TMP/$FILE" "$SNAPSHOTS/$FILE"
         exit 1
     else
       echo -e "  \e[92mOK\e[0m"


### PR DESCRIPTION
Hello there! I've bumped into the following issue.

With this setup:
```
$ node --version
v13.8.0
$ npm --version
6.13.6
$ npx elm-review --version
2.3.0
```

Running the following commands:
```
$ git clone git@github.com:jfmengels/elm-review-unused.git
$ cd elm-review-unused
$ npm install
$ npm test
```

Led to this error:

```
An error occurred while trying to check whether the preview configuration compiles.
Error: Command failed: npx elm-review --config /Users/arkham/code/elm-review-unused-test/preview --report=json
    at checkExecSyncError (child_process.js:611:11)
    at execSync (child_process.js:647:15)
    at checkThatExampleCompiles (/Users/arkham/code/elm-review-unused-test/elm-review-package-tests/check-previews-compile.js:16:5)
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/arkham/code/elm-review-unused-test/elm-review-package-tests/check-previews-compile.js:12:29)
    at Module._compile (internal/modules/cjs/loader.js:1151:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1171:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
```

Which was caused by the output of elm-review being cut at 8192 characters.

Doing some digging this seems to be a common issue in NodeJS when doing something like:
```
console.log(veryLargeString);
process.exit();
```
Check out these links for more info:
- https://nodejs.org/api/process.html#process_process_exit_code
- https://github.com/nodejs/node/issues/6456
- https://github.com/nodejs/node/issues/19218

So in this PR I changed the `report` function to be async and replaced `console.log` with `process.stdout.write`, which allows to be passed a callback when the write has been finished (https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback). I also promisified it so we don't have to pass that callback from the normal code.

With this fix in place, running `npm test` in the above setup succeeds.

I have no idea about NodeJS development in general, so please let me know if this looks good to you.