### PR TITLE
Improve elm-json stderr message extraction

### DIFF
--- a/lib/template-dependencies.js
+++ b/lib/template-dependencies.js
@@ -6,7 +6,7 @@ const path = require('path');
 const util = require('util');
 const crypto = require('crypto');
 const fs = require('fs-extra');
-const spawnAsync = require('cross-spawn-promise');
+const spawnAsync = require('cross-spawn');
 const ErrorMessage = require('./error-message');
 const getExecutable = require('elm-tooling/getExecutable');
 
@@ -71,14 +71,16 @@ ${formatElmJsonError(error, options)}`,
 }
 
 function formatElmJsonError(error, options) {
-  if (error.stderr === undefined || error.stderr === null) {
+  if (error.stderr === undefined) {
     return error.message;
   }
 
   const stderrMessage = error.stderr.toString().trim();
   const exec = /^([^]+\n)?--\s([A-Z ]+)\s-*\n\n([^]+)$/.exec(stderrMessage);
   if (exec === null) {
-    return `${error.message}\n\n${stderrMessage}`;
+    return `${error.message}\n\n${
+      stderrMessage === '' ? '(empty stderr)' : stderrMessage
+    }`;
   }
 
   const [, before, title, message] = exec;
@@ -174,12 +176,51 @@ ${error.message}`
     });
   }
 
-  return elmJsonPromise.then((elmJsonCLI) =>
-    spawnAsync(elmJsonCLI, args, {
-      silent: true,
-      env: process.env
-    })
+  return elmJsonPromise.then(
+    (elmJsonCLI) =>
+      new Promise((resolve, reject) => {
+        const child = spawnAsync(elmJsonCLI, args, {
+          silent: true,
+          env: process.env
+        });
+        let stdout = '';
+        let stderr = '';
+
+        child.on('error', reject);
+
+        child.stdout.on('data', (chunk) => {
+          stdout += chunk.toString();
+        });
+
+        child.stderr.on('data', (chunk) => {
+          stderr += chunk.toString();
+        });
+
+        child.on('close', (code, signal) => {
+          if (code === 0) {
+            resolve(stdout);
+          } else {
+            const error = new Error(
+              `elm-json exited with ${exitReason(code, signal)}`
+            );
+            error.stderr = stderr;
+            reject(error);
+          }
+        });
+      })
   );
+}
+
+function exitReason(code, signal) {
+  if (code !== null) {
+    return `exit code ${code}`;
+  }
+
+  if (signal !== null) {
+    return `signal ${signal}`;
+  }
+
+  return 'unknown reason';
 }
 
 function handleInternetAccessError(error) {

--- a/lib/template-dependencies.js
+++ b/lib/template-dependencies.js
@@ -47,23 +47,11 @@ async function get(options, elmJsonDependencies, pathToElmJson) {
     pathToElmJson
   ])
     .catch((error) => {
-      const stderrMessage = error.stderr.toString().trim();
-      const exec = /^--\s([A-Z ]+)\s-*\n\n((.|\n)*)/.exec(stderrMessage);
-      if (exec === null) {
-        throw error;
-      }
-
-      const [, title, message] = exec;
-      const formattedError = ErrorMessage.formatHuman(
-        options.debug,
-        new ErrorMessage.CustomError(title, message)
-      );
-
       throw new ErrorMessage.CustomError(
         'CONFIGURATION COMPILATION ERROR',
         `I encountered a problem when solving dependencies:
 
-${formattedError}`,
+${formatElmJsonError(error, options)}`,
         null
       );
     })
@@ -80,6 +68,27 @@ ${formattedError}`,
       return dependencies;
     })
     .catch(handleInternetAccessError);
+}
+
+function formatElmJsonError(error, options) {
+  if (error.stderr === undefined || error.stderr === null) {
+    return error.message;
+  }
+
+  const stderrMessage = error.stderr.toString().trim();
+  const exec = /^([^]+\n)?--\s([A-Z ]+)\s-*\n\n([^]+)$/.exec(stderrMessage);
+  if (exec === null) {
+    return `${error.message}\n\n${stderrMessage}`;
+  }
+
+  const [, before, title, message] = exec;
+  return ErrorMessage.formatHuman(
+    options.debug,
+    new ErrorMessage.CustomError(
+      title,
+      before === undefined ? message : `${message}\n\n${before}`
+    )
+  );
 }
 
 function hash(content) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1661,34 +1661,6 @@
         }
       }
     },
-    "cross-spawn-promise": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn-promise/-/cross-spawn-promise-0.10.2.tgz",
-      "integrity": "sha512-74PXJf6DYaab2klRS+D+9qxKJL1Weo3/ao9OPoH6NFzxtINSa/HE2mcyAPu1fpEmRTPD4Gdmpg3xEXQSgI8lpg==",
-      "requires": {
-        "cross-spawn": "^5.1.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -4607,15 +4579,6 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5739,11 +5702,6 @@
       "integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
       "dev": true
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "psl": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
@@ -6302,6 +6260,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -6309,7 +6268,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -7747,11 +7707,6 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yaml": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "chalk": "^4.0.0",
     "chokidar": "^3.4.0",
     "cross-spawn": "^7.0.3",
-    "cross-spawn-promise": "^0.10.2",
     "elm-tooling": "^1.0.1",
     "find-up": "^4.1.0",
     "folder-hash": "^3.3.0",


### PR DESCRIPTION
Previously, if elm-json failed to connect to package.elm-lang.org (in an environment with no cache) the following error message was printed:

```
-- UNEXPECTED ERROR ------------------------------------------------------------

I ran into an unexpected error. Please open an issue at the following link:
  jfmengels/node-elm-review/issues/new

Please include this error message and as much detail as you can provide. If you
can, please provide a setup that makes it easy to reproduce the error. That will
make it much easier to fix the issue.

Below is the error that was encountered.
--------------------------------------------------------------------------------
Error: Exited with status 1
    at closeArgsToError (/nix/store/hw5vcijxs0d83gwn8f220bqif3f47kl5-node_elm-review-2.4.0/lib/node_modules/elm-review/node_modules/cross-spawn-promise/lib/index.js:20:16)
    at ChildProcess.<anonymous> (/nix/store/hw5vcijxs0d83gwn8f220bqif3f47kl5-node_elm-review-2.4.0/lib/node_modules/elm-review/node_modules/cross-spawn-promise/lib/index.js:76:19)
    at Object.onceWrapper (events.js:422:26)
    at ChildProcess.emit (events.js:315:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
```

Now it looks like this instead:

```
-- CONFIGURATION COMPILATION ERROR ---------------------------------------------

I encountered a problem when solving dependencies:

-- NO VALID PACKAGE VERSION ----------------------------------------------------

Because elm/json does not appear to exist and this project depends on elm/json
at any version, no valid set of package versions could be found.

phase: retrieve
 Jan 22 18:15:41.748 WARN Failed to fetch versions from package.elm-lang.org
```

While at it, I replaced `cross-spawn-promise` with just `cross-spawn` (which was already a dependency). `cross-spawn-promise` depends on `cross-spawn` 5.x, while the latest `cross-spawn` is 7.x.