### PR TITLE
Consider when elm-tooling is running in "CI mode"

### DIFF
--- a/lib/template-dependencies.js
+++ b/lib/template-dependencies.js
@@ -176,39 +176,42 @@ ${error.message}`
     });
   }
 
-  return elmJsonPromise.then(
-    (elmJsonCLI) =>
-      new Promise((resolve, reject) => {
-        const child = spawnAsync(elmJsonCLI, args, {
-          silent: true,
-          env: process.env
-        });
-        let stdout = '';
-        let stderr = '';
+  return elmJsonPromise.then((elmJsonCLI) => {
+    // For CI elm-tooling returns the value of 0. CI environments
+    // are defined when the env var NO_ELM_TOOLING_INSTALL exists
+    if (elmJsonCLI === 0) return;
 
-        child.on('error', reject);
+    return new Promise((resolve, reject) => {
+      const child = spawnAsync(elmJsonCLI, args, {
+        silent: true,
+        env: process.env
+      });
+      let stdout = '';
+      let stderr = '';
 
-        child.stdout.on('data', (chunk) => {
-          stdout += chunk.toString();
-        });
+      child.on('error', reject);
 
-        child.stderr.on('data', (chunk) => {
-          stderr += chunk.toString();
-        });
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString();
+      });
 
-        child.on('close', (code, signal) => {
-          if (code === 0) {
-            resolve(stdout);
-          } else {
-            const error = new Error(
-              `elm-json exited with ${exitReason(code, signal)}`
-            );
-            error.stderr = stderr;
-            reject(error);
-          }
-        });
-      })
-  );
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+
+      child.on('close', (code, signal) => {
+        if (code === 0) {
+          resolve(stdout);
+        } else {
+          const error = new Error(
+            `elm-json exited with ${exitReason(code, signal)}`
+          );
+          error.stderr = stderr;
+          reject(error);
+        }
+      });
+    });
+  });
 }
 
 function exitReason(code, signal) {


### PR DESCRIPTION
In the situation where `elm-tooling` in running in [ci mode](https://elm-tooling.github.io/elm-tooling-cli/ci/), a user can set an environment variable and `elm-tooling` will assume that the dependencies are implicitly available on the system. In this case, either the system tools are used or the run will fail.

This PR let's `elm-review` consider the CI usage of `elm-tooling` by checking that the return result from the call to `getExecutable` is the integer 0, as opposed to the expected path string.

I'd be more than happy to rework this based on any feedback.