### PR TITLE
Improved error handling and reporting of CLI flag misuses

### DIFF
--- a/lib/flags.js
+++ b/lib/flags.js
@@ -228,6 +228,21 @@ const flags = [
     description: []
   },
   {
+    name: 'github-auth',
+    boolean: false,
+    whatItNeeds: 'your GitHub API token',
+    argName: '<github-api-token>',
+    exampleArg: 'my-user-name:abcdef01234567890',
+    usesEquals: true,
+    color: chalk.cyan,
+    section: 'none',
+    description: [
+      `To be used along with ${chalk.cyan(
+        '--template'
+      )} to avoid GitHub rate limiting. Follow https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token. The API token needs access to public repositories.`
+    ]
+  },
+  {
     name: 'namespace',
     boolean: false,
     whatItNeeds: 'the name of the tool using elm-review',

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -77,8 +77,8 @@ const flags = [
       'Copy the review configuration from a GitHub repository, at the root or',
       'in a folder.',
       'Examples:',
-      '- elm-review init --template author/elm-review-configuration',
-      '- elm-review init --template jfmengels/elm-review-unused/example#master'
+      '  - elm-review init --template author/elm-review-configuration',
+      '  - elm-review init --template jfmengels/elm-review-unused/example#master'
     ]
   },
   {

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -50,6 +50,18 @@ const flags = [
     ]
   },
   {
+    name: 'config',
+    boolean: false,
+    argName: '<path-to-review-directory>',
+    usesEquals: false,
+    color: chalk.cyan,
+    section: 'init',
+    description: [
+      'Create the configuration files in the specified directory instead of in',
+      'the review/ directory.'
+    ]
+  },
+  {
     name: 'template',
     boolean: false,
     argName: '<author>/<repo>[/path-to-the-config-folder][#branch-or-commit]',

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -104,6 +104,13 @@ const flags = {
       ]
     },
     {
+      name: 'help',
+      boolean: true,
+      color: chalk.cyan,
+      section: 'hidden',
+      description: []
+    },
+    {
       name: 'debug',
       boolean: true,
       color: chalk.cyan,

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -250,7 +250,11 @@ const flags = [
     description: [
       `To be used along with ${chalk.cyan(
         '--template'
-      )} to avoid GitHub rate limiting. Follow https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token. The API token needs access to public repositories.`
+      )} to avoid GitHub rate limiting.`,
+      'Follow https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token. The API token needs access to public repositories.',
+      '',
+      'Then use the flag like this:',
+      chalk.greenBright('  --github-auth=my-user-name:abcdef01234567890')
     ]
   },
   {

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -206,6 +206,27 @@ const flags = {
       color: chalk.cyan,
       section: 'fix',
       description: [`Specify the path to ${chalk.magentaBright('elm-format')}.`]
+    },
+    {
+      name: 'benchmark-info',
+      boolean: true,
+      color: chalk.blueBright,
+      section: 'none',
+      description: []
+    },
+    {
+      name: 'ignore-problematic-dependencies',
+      boolean: true,
+      color: chalk.blueBright,
+      section: 'none',
+      description: []
+    },
+    {
+      name: 'FOR-TESTS',
+      boolean: true,
+      color: chalk.blueBright,
+      section: 'none',
+      description: []
     }
   ]
 };

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -47,16 +47,8 @@ const flags = [
     description: [
       'Use the review configuration in the specified directory instead of the',
       'one found in the current directory or one of its parents.'
-    ]
-  },
-  {
-    name: 'config',
-    boolean: false,
-    argName: '<path-to-review-directory>',
-    usesEquals: false,
-    color: chalk.cyan,
-    sections: ['init'],
-    description: [
+    ],
+    initDescription: [
       'Create the configuration files in the specified directory instead of in',
       'the review/ directory.'
     ]
@@ -258,17 +250,28 @@ const flags = [
   }
 ];
 
-function buildFlags({section}) {
+function buildFlags({section, subcommand}) {
   return flags
     .filter((flag) => flag.sections.includes(section))
-    .map(buildFlag)
+    .map((flag) => buildFlag(subcommand, flag))
     .join('\n\n');
 }
 
-function buildFlag(flag) {
+function buildFlag(subcommand, flag) {
   const flagArgs = buildFlagsArgs(flag);
+  const preferredDescriptionField = preferredDescriptionFieldFor(subcommand);
+  const description = flag[preferredDescriptionField] || flag.description;
   return `    ${flag.color(`--${flag.name}${flagArgs}`)}
-${flag.description.map((desc) => (desc ? `        ${desc}` : '')).join('\n')}`;
+${description.map((desc) => (desc ? `        ${desc}` : '')).join('\n')}`;
+}
+
+function preferredDescriptionFieldFor(subcommand) {
+  switch (subcommand) {
+    case 'init':
+      return 'initDescription';
+    default:
+      return 'description';
+  }
 }
 
 function buildFlagsArgs(flag) {

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -43,7 +43,7 @@ const flags = [
     argName: '<path-to-review-directory>',
     usesEquals: false,
     color: chalk.cyan,
-    sections: ['regular'],
+    sections: ['regular', 'init'],
     description: [
       'Use the review configuration in the specified directory instead of the',
       'one found in the current directory or one of its parents.'

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -1,72 +1,71 @@
 const chalk = require('chalk');
 
-const flags = {
-  '*no subcommand*': [
-    {
-      name: 'rules',
-      boolean: false,
-      argName: '<rule1,rule2,...>',
-      whatItNeeds: 'the list of rules to enable separated by commas',
-      exampleArg: 'NoThis,NoThat',
-      usesEquals: false,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        'Run with a subsection of the rules in the configuration. Specify them',
-        'by their name, and separate them by commas.'
-      ]
-    },
-    {
-      name: 'watch',
-      boolean: true,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        /* eslint-disable prettier/prettier */
+const flags = [
+  {
+    name: 'rules',
+    boolean: false,
+    argName: '<rule1,rule2,...>',
+    whatItNeeds: 'the list of rules to enable separated by commas',
+    exampleArg: 'NoThis,NoThat',
+    usesEquals: false,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      'Run with a subsection of the rules in the configuration. Specify them',
+      'by their name, and separate them by commas.'
+    ]
+  },
+  {
+    name: 'watch',
+    boolean: true,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      /* eslint-disable prettier/prettier */
         `Re-run ${chalk.greenBright('elm-review')} automatically when your project changes.`,
         `You can use ${chalk.cyan('--watch')} and ${chalk.blueBright('--fix')} together.`
         /* eslint-enable prettier/prettier */
-      ]
-    },
-    {
-      name: 'elmjson',
-      boolean: false,
-      whatItNeeds: "the path to the project's elm.json",
-      argName: '<path-to-elm.json>',
-      exampleArg: 'elm.json',
-      usesEquals: false,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        'Specify the path to the elm.json file of the project. By default,',
-        'the one in the current directory or its parent directories will be used.'
-      ]
-    },
-    {
-      name: 'config',
-      boolean: false,
-      whatItNeeds: 'the path to the review configuration directory',
-      argName: '<path-to-review-directory>',
-      exampleArg: 'review/',
-      usesEquals: false,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        'Use the review configuration in the specified directory instead of the',
-        'one found in the current directory or one of its parents.'
-      ]
-    },
-    {
-      name: 'template',
-      boolean: false,
-      whatItNeeds: 'the GitHub repository',
-      argName: '<author>/<repo>[/path-to-the-config-folder][#branch-or-commit]',
-      exampleArg: 'jfmengels/elm-review-unused/example',
-      usesEquals: false,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        /* eslint-disable prettier/prettier */
+    ]
+  },
+  {
+    name: 'elmjson',
+    boolean: false,
+    whatItNeeds: "the path to the project's elm.json",
+    argName: '<path-to-elm.json>',
+    exampleArg: 'elm.json',
+    usesEquals: false,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      'Specify the path to the elm.json file of the project. By default,',
+      'the one in the current directory or its parent directories will be used.'
+    ]
+  },
+  {
+    name: 'config',
+    boolean: false,
+    whatItNeeds: 'the path to the review configuration directory',
+    argName: '<path-to-review-directory>',
+    exampleArg: 'review/',
+    usesEquals: false,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      'Use the review configuration in the specified directory instead of the',
+      'one found in the current directory or one of its parents.'
+    ]
+  },
+  {
+    name: 'template',
+    boolean: false,
+    whatItNeeds: 'the GitHub repository',
+    argName: '<author>/<repo>[/path-to-the-config-folder][#branch-or-commit]',
+    exampleArg: 'jfmengels/elm-review-unused/example',
+    usesEquals: false,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      /* eslint-disable prettier/prettier */
         'Use the review configuration from a GitHub repository. You can use this',
         `to try out ${chalk.greenBright('elm-review')}, a configuration or a single rule.`,
         'This flag requires Internet access, even after the first run.',
@@ -77,170 +76,169 @@ const flags = {
         `I recommend to only use this temporarily, and run ${chalk.yellowBright('elm-review init')} with`,
         'this same flag to copy the configuration to your project.',
         /* eslint-enable prettier/prettier */
-      ]
-    },
-    {
-      name: 'compiler',
-      boolean: false,
-      whatItNeeds: 'the path to the Elm binary',
-      argName: '<path-to-elm>',
-      exampleArg: 'node_modules/.bin/elm',
-      usesEquals: false,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        `Specify the path to the ${chalk.magentaBright('elm')} compiler.`
-      ]
-    },
-    {
-      name: 'version',
-      alias: 'v',
-      boolean: true,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        /* eslint-disable prettier/prettier */
+    ]
+  },
+  {
+    name: 'compiler',
+    boolean: false,
+    whatItNeeds: 'the path to the Elm binary',
+    argName: '<path-to-elm>',
+    exampleArg: 'node_modules/.bin/elm',
+    usesEquals: false,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      `Specify the path to the ${chalk.magentaBright('elm')} compiler.`
+    ]
+  },
+  {
+    name: 'version',
+    alias: 'v',
+    boolean: true,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      /* eslint-disable prettier/prettier */
         `Print the version of the ${chalk.greenBright('elm-review')} CLI.`,
         /* eslint-enable prettier/prettier */
-      ]
-    },
-    {
-      name: 'help',
-      alias: 'h',
-      boolean: true,
-      color: chalk.cyan,
-      section: 'hidden',
-      description: []
-    },
-    {
-      name: 'debug',
-      boolean: true,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        /* eslint-disable prettier/prettier */
+    ]
+  },
+  {
+    name: 'help',
+    alias: 'h',
+    boolean: true,
+    color: chalk.cyan,
+    section: 'hidden',
+    description: []
+  },
+  {
+    name: 'debug',
+    boolean: true,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      /* eslint-disable prettier/prettier */
         'Add helpful information to debug your configuration or rules.',
         '- Print the list of reviewed files.',
         `- Run the compiler in debug mode, allowing you to use ${chalk.yellow('Debug')} statements`,
         '  in your configuration and custom rules.',
         /* eslint-enable prettier/prettier */
-      ]
-    },
-    {
-      name: 'report',
-      boolean: false,
-      whatItNeeds: 'the report format',
-      argName: '<json or ndjson>',
-      exampleArg: 'json',
-      usesEquals: true,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        /* eslint-disable prettier/prettier */
+    ]
+  },
+  {
+    name: 'report',
+    boolean: false,
+    whatItNeeds: 'the report format',
+    argName: '<json or ndjson>',
+    exampleArg: 'json',
+    usesEquals: true,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      /* eslint-disable prettier/prettier */
         `Error reports will be in JSON format. ${chalk.magenta('json')} prints a single JSON object`,
         `while ${chalk.magenta('ndjson')} will print one JSON object per error each on a new line.`,
         'The formats are described in this document: https://bit.ly/31F6jzz'
         /* eslint-enable prettier/prettier */
-      ]
-    },
-    {
-      name: 'no-details',
-      boolean: true,
-      color: chalk.cyan,
-      section: 'regular',
-      description: [
-        'Hide the details from error reports for a more compact view.'
-      ]
-    },
-    {
-      name: 'details',
-      boolean: true,
-      color: chalk.cyan,
-      section: 'none',
-      description: []
-    },
-    {
-      name: 'fix',
-      boolean: true,
-      color: chalk.blueBright,
-      section: 'fix',
-      description: [
-        /* eslint-disable prettier/prettier */
+    ]
+  },
+  {
+    name: 'no-details',
+    boolean: true,
+    color: chalk.cyan,
+    section: 'regular',
+    description: [
+      'Hide the details from error reports for a more compact view.'
+    ]
+  },
+  {
+    name: 'details',
+    boolean: true,
+    color: chalk.cyan,
+    section: 'none',
+    description: []
+  },
+  {
+    name: 'fix',
+    boolean: true,
+    color: chalk.blueBright,
+    section: 'fix',
+    description: [
+      /* eslint-disable prettier/prettier */
         `${chalk.greenBright('elm-review')} will present fixes for the errors that offer an automatic`,
         'fix, which you can then accept or refuse one by one. When there are no',
         `more fixable errors left, ${chalk.greenBright('elm-review')} will report the remaining errors as`,
         `if it was called without ${chalk.blueBright('--fix')}.`,
         `Fixed files will be reformatted using ${chalk.magentaBright('elm-format')}.`
         /* eslint-enable prettier/prettier */
-      ]
-    },
-    {
-      name: 'fix-all',
-      boolean: true,
-      color: chalk.blueBright,
-      section: 'fix',
-      description: [
-        /* eslint-disable prettier/prettier */
+    ]
+  },
+  {
+    name: 'fix-all',
+    boolean: true,
+    color: chalk.blueBright,
+    section: 'fix',
+    description: [
+      /* eslint-disable prettier/prettier */
         `${chalk.greenBright('elm-review')} will present a single fix containing the application of all`,
         'available automatic fixes, which you can then accept or refuse.',
         `Afterwards, ${chalk.greenBright('elm-review')} will report the remaining errors as if it was`,
         `called without ${chalk.blueBright('--fix-all')}.`,
         `Fixed files will be reformatted using ${chalk.magentaBright('elm-format')}.`
         /* eslint-enable prettier/prettier */
-      ]
-    },
-    {
-      name: 'fix-all-without-prompt',
-      boolean: true,
-      color: chalk.blueBright,
-      section: 'none',
-      description: []
-    },
-    {
-      name: 'elm-format-path',
-      boolean: false,
-      whatItNeeds: 'the path to the elm-format binary',
-      argName: '<path-to-elm-format>',
-      exampleArg: 'node_modules/.bin/elm-format',
-      usesEquals: false,
-      color: chalk.cyan,
-      section: 'fix',
-      description: [`Specify the path to ${chalk.magentaBright('elm-format')}.`]
-    },
-    {
-      name: 'benchmark-info',
-      boolean: true,
-      color: chalk.blueBright,
-      section: 'none',
-      description: []
-    },
-    {
-      name: 'ignore-problematic-dependencies',
-      boolean: true,
-      color: chalk.blueBright,
-      section: 'none',
-      description: []
-    },
-    {
-      name: 'FOR-TESTS',
-      boolean: true,
-      color: chalk.blueBright,
-      section: 'none',
-      description: []
-    },
-    {
-      name: 'namespace',
-      boolean: false,
-      whatItNeeds: 'the name of the tool using elm-review',
-      argName: '<namespace>',
-      exampleArg: 'my-ide-name',
-      usesEquals: false,
-      color: chalk.cyan,
-      section: 'none',
-      description: []
-    }
-  ]
-};
+    ]
+  },
+  {
+    name: 'fix-all-without-prompt',
+    boolean: true,
+    color: chalk.blueBright,
+    section: 'none',
+    description: []
+  },
+  {
+    name: 'elm-format-path',
+    boolean: false,
+    whatItNeeds: 'the path to the elm-format binary',
+    argName: '<path-to-elm-format>',
+    exampleArg: 'node_modules/.bin/elm-format',
+    usesEquals: false,
+    color: chalk.cyan,
+    section: 'fix',
+    description: [`Specify the path to ${chalk.magentaBright('elm-format')}.`]
+  },
+  {
+    name: 'benchmark-info',
+    boolean: true,
+    color: chalk.blueBright,
+    section: 'none',
+    description: []
+  },
+  {
+    name: 'ignore-problematic-dependencies',
+    boolean: true,
+    color: chalk.blueBright,
+    section: 'none',
+    description: []
+  },
+  {
+    name: 'FOR-TESTS',
+    boolean: true,
+    color: chalk.blueBright,
+    section: 'none',
+    description: []
+  },
+  {
+    name: 'namespace',
+    boolean: false,
+    whatItNeeds: 'the name of the tool using elm-review',
+    argName: '<namespace>',
+    exampleArg: 'my-ide-name',
+    usesEquals: false,
+    color: chalk.cyan,
+    section: 'none',
+    description: []
+  }
+];
 
 function buildFlags(flagList) {
   return flagList.map(buildFlag).join('\n\n');

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -20,9 +20,9 @@ const flags = [
     section: 'regular',
     description: [
       /* eslint-disable prettier/prettier */
-        `Re-run ${chalk.greenBright('elm-review')} automatically when your project changes.`,
-        `You can use ${chalk.cyan('--watch')} and ${chalk.blueBright('--fix')} together.`
-        /* eslint-enable prettier/prettier */
+      `Re-run ${chalk.greenBright('elm-review')} automatically when your project changes.`,
+      `You can use ${chalk.cyan('--watch')} and ${chalk.blueBright('--fix')} together.`
+      /* eslint-enable prettier/prettier */
     ]
   },
   {

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -94,6 +94,7 @@ const flags = {
     },
     {
       name: 'version',
+      alias: 'v',
       boolean: true,
       color: chalk.cyan,
       section: 'regular',
@@ -105,6 +106,7 @@ const flags = {
     },
     {
       name: 'help',
+      alias: 'h',
       boolean: true,
       color: chalk.cyan,
       section: 'hidden',

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -7,7 +7,7 @@ const flags = [
     argName: '<rule1,rule2,...>',
     usesEquals: false,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       'Run with a subsection of the rules in the configuration. Specify them',
       'by their name, and separate them by commas.'
@@ -17,7 +17,7 @@ const flags = [
     name: 'watch',
     boolean: true,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       /* eslint-disable prettier/prettier */
       `Re-run ${chalk.greenBright('elm-review')} automatically when your project changes.`,
@@ -31,7 +31,7 @@ const flags = [
     argName: '<path-to-elm.json>',
     usesEquals: false,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       'Specify the path to the elm.json file of the project. By default,',
       'the one in the current directory or its parent directories will be used.'
@@ -43,7 +43,7 @@ const flags = [
     argName: '<path-to-review-directory>',
     usesEquals: false,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       'Use the review configuration in the specified directory instead of the',
       'one found in the current directory or one of its parents.'
@@ -55,7 +55,7 @@ const flags = [
     argName: '<path-to-review-directory>',
     usesEquals: false,
     color: chalk.cyan,
-    section: 'init',
+    sections: ['init'],
     description: [
       'Create the configuration files in the specified directory instead of in',
       'the review/ directory.'
@@ -67,7 +67,7 @@ const flags = [
     argName: '<author>/<repo>[/path-to-the-config-folder][#branch-or-commit]',
     usesEquals: false,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       /* eslint-disable prettier/prettier */
         'Use the review configuration from a GitHub repository. You can use this',
@@ -88,7 +88,7 @@ const flags = [
     argName: '<path-to-elm>',
     usesEquals: false,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       `Specify the path to the ${chalk.magentaBright('elm')} compiler.`
     ]
@@ -98,7 +98,7 @@ const flags = [
     alias: 'v',
     boolean: true,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       /* eslint-disable prettier/prettier */
         `Print the version of the ${chalk.greenBright('elm-review')} CLI.`,
@@ -110,14 +110,14 @@ const flags = [
     alias: 'h',
     boolean: true,
     color: chalk.cyan,
-    section: 'hidden',
+    sections: ['hidden'],
     description: []
   },
   {
     name: 'debug',
     boolean: true,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       /* eslint-disable prettier/prettier */
         'Add helpful information to debug your configuration or rules.',
@@ -133,7 +133,7 @@ const flags = [
     argName: '<json or ndjson>',
     usesEquals: true,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       /* eslint-disable prettier/prettier */
         `Error reports will be in JSON format. ${chalk.magenta('json')} prints a single JSON object`,
@@ -146,7 +146,7 @@ const flags = [
     name: 'no-details',
     boolean: true,
     color: chalk.cyan,
-    section: 'regular',
+    sections: ['regular'],
     description: [
       'Hide the details from error reports for a more compact view.'
     ]
@@ -155,14 +155,14 @@ const flags = [
     name: 'details',
     boolean: true,
     color: chalk.cyan,
-    section: 'none',
+    sections: [],
     description: []
   },
   {
     name: 'fix',
     boolean: true,
     color: chalk.blueBright,
-    section: 'fix',
+    sections: ['fix'],
     description: [
       /* eslint-disable prettier/prettier */
         `${chalk.greenBright('elm-review')} will present fixes for the errors that offer an automatic`,
@@ -177,7 +177,7 @@ const flags = [
     name: 'fix-all',
     boolean: true,
     color: chalk.blueBright,
-    section: 'fix',
+    sections: ['fix'],
     description: [
       /* eslint-disable prettier/prettier */
         `${chalk.greenBright('elm-review')} will present a single fix containing the application of all`,
@@ -192,7 +192,7 @@ const flags = [
     name: 'fix-all-without-prompt',
     boolean: true,
     color: chalk.blueBright,
-    section: 'none',
+    sections: [],
     description: []
   },
   {
@@ -201,28 +201,28 @@ const flags = [
     argName: '<path-to-elm-format>',
     usesEquals: false,
     color: chalk.cyan,
-    section: 'fix',
+    sections: ['fix'],
     description: [`Specify the path to ${chalk.magentaBright('elm-format')}.`]
   },
   {
     name: 'benchmark-info',
     boolean: true,
     color: chalk.blueBright,
-    section: 'none',
+    sections: [],
     description: []
   },
   {
     name: 'ignore-problematic-dependencies',
     boolean: true,
     color: chalk.blueBright,
-    section: 'none',
+    sections: [],
     description: []
   },
   {
     name: 'FOR-TESTS',
     boolean: true,
     color: chalk.blueBright,
-    section: 'none',
+    sections: [],
     description: []
   },
   {
@@ -231,7 +231,7 @@ const flags = [
     argName: '<github-api-token>',
     usesEquals: true,
     color: chalk.cyan,
-    section: 'none',
+    sections: [],
     description: [
       `To be used along with ${chalk.cyan(
         '--template'
@@ -244,7 +244,7 @@ const flags = [
     argName: '<namespace>',
     usesEquals: false,
     color: chalk.cyan,
-    section: 'none',
+    sections: [],
     description: []
   },
   {
@@ -253,14 +253,14 @@ const flags = [
     argName: '[author name[, package name[, license]]]',
     usesEquals: false,
     color: chalk.cyan,
-    section: 'none',
+    sections: [],
     description: []
   }
 ];
 
 function buildFlags({section}) {
   return flags
-    .filter((flag) => flag.section === section)
+    .filter((flag) => flag.sections.includes(section))
     .map(buildFlag)
     .join('\n\n');
 }

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -62,16 +62,16 @@ const flags = [
     sections: ['regular', 'init'],
     description: [
       /* eslint-disable prettier/prettier */
-        'Use the review configuration from a GitHub repository. You can use this',
-        `to try out ${chalk.greenBright('elm-review')}, a configuration or a single rule.`,
-        'This flag requires Internet access, even after the first run.',
-        'Examples:',
-        '  - elm-review --template author/elm-review-configuration',
-        '  - elm-review --template jfmengels/elm-review-unused/example#master',
-        '',
-        `I recommend to only use this temporarily, and run ${chalk.yellowBright('elm-review init')} with`,
-        'this same flag to copy the configuration to your project.',
-        /* eslint-enable prettier/prettier */
+      'Use the review configuration from a GitHub repository. You can use this',
+      `to try out ${chalk.greenBright('elm-review')}, a configuration or a single rule.`,
+      'This flag requires Internet access, even after the first run.',
+      'Examples:',
+      '  - elm-review --template author/elm-review-configuration',
+      '  - elm-review --template jfmengels/elm-review-unused/example#master',
+      '',
+      `I recommend to only use this temporarily, and run ${chalk.yellowBright('elm-review init')} with`,
+      'this same flag to copy the configuration to your project.',
+      /* eslint-enable prettier/prettier */
     ],
     initDescription: [
       'Copy the review configuration from a GitHub repository, at the root or',

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -190,6 +190,13 @@ const flags = {
       ]
     },
     {
+      name: 'fix-all-without-prompt',
+      boolean: true,
+      color: chalk.blueBright,
+      section: 'none',
+      description: []
+    },
+    {
       name: 'elm-format-path',
       boolean: false,
       whatItNeeds: 'the path to the elm-format binary',

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -227,6 +227,17 @@ const flags = {
       color: chalk.blueBright,
       section: 'none',
       description: []
+    },
+    {
+      name: 'namespace',
+      boolean: false,
+      whatItNeeds: 'the name of the tool using elm-review',
+      argName: '<namespace>',
+      exampleArg: 'my-ide-name',
+      usesEquals: false,
+      color: chalk.cyan,
+      section: 'none',
+      description: []
     }
   ]
 };

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -4,7 +4,6 @@ const flags = {
   '*no subcommand*': [
     {
       name: 'rules',
-      public: true,
       boolean: false,
       argName: '<rule1,rule2,...>',
       whatItNeeds: 'the list of rules to enable separated by commas',
@@ -19,7 +18,6 @@ const flags = {
     },
     {
       name: 'watch',
-      public: true,
       boolean: true,
       color: chalk.cyan,
       section: 'regular',
@@ -32,7 +30,6 @@ const flags = {
     },
     {
       name: 'elmjson',
-      public: true,
       boolean: false,
       whatItNeeds: "the path to the project's elm.json",
       argName: '<path-to-elm.json>',
@@ -47,7 +44,6 @@ const flags = {
     },
     {
       name: 'config',
-      public: true,
       boolean: false,
       whatItNeeds: 'the path to the review configuration directory',
       argName: '<path-to-review-directory>',
@@ -62,7 +58,6 @@ const flags = {
     },
     {
       name: 'template',
-      public: true,
       boolean: false,
       whatItNeeds: 'the GitHub repository',
       argName: '<author>/<repo>[/path-to-the-config-folder][#branch-or-commit]',
@@ -86,7 +81,6 @@ const flags = {
     },
     {
       name: 'compiler',
-      public: true,
       boolean: false,
       whatItNeeds: 'the path to the Elm binary',
       argName: '<path-to-elm>',
@@ -100,7 +94,6 @@ const flags = {
     },
     {
       name: 'version',
-      public: true,
       boolean: true,
       color: chalk.cyan,
       section: 'regular',
@@ -112,7 +105,6 @@ const flags = {
     },
     {
       name: 'debug',
-      public: true,
       boolean: true,
       color: chalk.cyan,
       section: 'regular',
@@ -127,7 +119,6 @@ const flags = {
     },
     {
       name: 'report',
-      public: true,
       boolean: false,
       whatItNeeds: 'the report format',
       argName: '<json or ndjson>',
@@ -145,7 +136,6 @@ const flags = {
     },
     {
       name: 'no-details',
-      public: true,
       boolean: true,
       color: chalk.cyan,
       section: 'regular',
@@ -155,7 +145,6 @@ const flags = {
     },
     {
       name: 'fix',
-      public: true,
       boolean: true,
       color: chalk.blueBright,
       section: 'fix',
@@ -171,7 +160,6 @@ const flags = {
     },
     {
       name: 'fix-all',
-      public: true,
       boolean: true,
       color: chalk.blueBright,
       section: 'fix',
@@ -187,7 +175,6 @@ const flags = {
     },
     {
       name: 'elm-format-path',
-      public: true,
       boolean: false,
       whatItNeeds: 'the path to the elm-format binary',
       argName: '<path-to-elm-format>',
@@ -201,10 +188,7 @@ const flags = {
 };
 
 function buildFlags(flagList) {
-  return flagList
-    .filter((flag) => flag.public)
-    .map(buildFlag)
-    .join('\n\n');
+  return flagList.map(buildFlag).join('\n\n');
 }
 
 function buildFlag(flag) {

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -5,8 +5,6 @@ const flags = [
     name: 'rules',
     boolean: false,
     argName: '<rule1,rule2,...>',
-    whatItNeeds: 'the list of rules to enable separated by commas',
-    exampleArg: 'NoThis,NoThat',
     usesEquals: false,
     color: chalk.cyan,
     section: 'regular',
@@ -30,9 +28,7 @@ const flags = [
   {
     name: 'elmjson',
     boolean: false,
-    whatItNeeds: "the path to the project's elm.json",
     argName: '<path-to-elm.json>',
-    exampleArg: 'elm.json',
     usesEquals: false,
     color: chalk.cyan,
     section: 'regular',
@@ -44,9 +40,7 @@ const flags = [
   {
     name: 'config',
     boolean: false,
-    whatItNeeds: 'the path to the review configuration directory',
     argName: '<path-to-review-directory>',
-    exampleArg: 'review/',
     usesEquals: false,
     color: chalk.cyan,
     section: 'regular',
@@ -58,9 +52,7 @@ const flags = [
   {
     name: 'template',
     boolean: false,
-    whatItNeeds: 'the GitHub repository',
     argName: '<author>/<repo>[/path-to-the-config-folder][#branch-or-commit]',
-    exampleArg: 'jfmengels/elm-review-unused/example',
     usesEquals: false,
     color: chalk.cyan,
     section: 'regular',
@@ -81,9 +73,7 @@ const flags = [
   {
     name: 'compiler',
     boolean: false,
-    whatItNeeds: 'the path to the Elm binary',
     argName: '<path-to-elm>',
-    exampleArg: 'node_modules/.bin/elm',
     usesEquals: false,
     color: chalk.cyan,
     section: 'regular',
@@ -128,9 +118,7 @@ const flags = [
   {
     name: 'report',
     boolean: false,
-    whatItNeeds: 'the report format',
     argName: '<json or ndjson>',
-    exampleArg: 'json',
     usesEquals: true,
     color: chalk.cyan,
     section: 'regular',
@@ -198,9 +186,7 @@ const flags = [
   {
     name: 'elm-format-path',
     boolean: false,
-    whatItNeeds: 'the path to the elm-format binary',
     argName: '<path-to-elm-format>',
-    exampleArg: 'node_modules/.bin/elm-format',
     usesEquals: false,
     color: chalk.cyan,
     section: 'fix',
@@ -230,9 +216,7 @@ const flags = [
   {
     name: 'github-auth',
     boolean: false,
-    whatItNeeds: 'your GitHub API token',
     argName: '<github-api-token>',
-    exampleArg: 'my-user-name:abcdef01234567890',
     usesEquals: true,
     color: chalk.cyan,
     section: 'none',
@@ -245,9 +229,7 @@ const flags = [
   {
     name: 'namespace',
     boolean: false,
-    whatItNeeds: 'the name of the tool using elm-review',
     argName: '<namespace>',
-    exampleArg: 'my-ide-name',
     usesEquals: false,
     color: chalk.cyan,
     section: 'none',
@@ -256,9 +238,7 @@ const flags = [
   {
     name: 'prefill',
     boolean: false,
-    whatItNeeds: 'the answers to the interactive prompts',
     argName: '[author name[, package name[, license]]]',
-    exampleArg: 'my-username,elm-review-great-things,MIT',
     usesEquals: false,
     color: chalk.cyan,
     section: 'none',
@@ -287,6 +267,7 @@ function buildFlagsArgs(flag) {
 
 module.exports = {
   flags,
+  buildFlag,
   buildFlags,
   buildFlagsArgs
 };

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -258,8 +258,11 @@ const flags = [
   }
 ];
 
-function buildFlags(flagList) {
-  return flagList.map(buildFlag).join('\n\n');
+function buildFlags(section) {
+  return flags
+    .filter((flag) => flag.section === section)
+    .map(buildFlag)
+    .join('\n\n');
 }
 
 function buildFlag(flag) {

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -87,9 +87,17 @@ const flags = [
     argName: '<path-to-elm>',
     usesEquals: false,
     color: chalk.cyan,
-    sections: ['regular'],
+    sections: ['regular', 'init'],
     description: [
       `Specify the path to the ${chalk.magentaBright('elm')} compiler.`
+    ],
+    initDescription: [
+      /* eslint-disable prettier/prettier */
+      `Specify the path to the ${chalk.magentaBright('elm')} compiler.`,
+      `The ${chalk.magentaBright('elm')} compiler is used to know the version of the compiler to write`,
+      `down in the ${chalk.yellowBright('review/elm.json')} file’s \`elm-version\` field. Use this if you`,
+      `have multiple versions of the ${chalk.magentaBright('elm')} compiler on your device.`
+      /* eslint-enable prettier/prettier */
     ]
   },
   {

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -273,7 +273,7 @@ function buildFlags(flagList) {
 function buildFlag(flag) {
   const flagArgs = buildFlagsArgs(flag);
   return `    ${flag.color(`--${flag.name}${flagArgs}`)}
-${flag.description.map((desc) => `        ${desc}`).join('\n')}`;
+${flag.description.map((desc) => (desc ? `        ${desc}` : '')).join('\n')}`;
 }
 
 function buildFlagsArgs(flag) {

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -258,7 +258,7 @@ const flags = [
   }
 ];
 
-function buildFlags(section) {
+function buildFlags({section}) {
   return flags
     .filter((flag) => flag.section === section)
     .map(buildFlag)

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -237,6 +237,17 @@ const flags = [
     color: chalk.cyan,
     section: 'none',
     description: []
+  },
+  {
+    name: 'prefill',
+    boolean: false,
+    whatItNeeds: 'the answers to the interactive prompts',
+    argName: '[author name[, package name[, license]]]',
+    exampleArg: 'my-username,elm-review-great-things,MIT',
+    usesEquals: false,
+    color: chalk.cyan,
+    section: 'none',
+    description: []
   }
 ];
 

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -153,6 +153,13 @@ const flags = {
       ]
     },
     {
+      name: 'details',
+      boolean: true,
+      color: chalk.cyan,
+      section: 'none',
+      description: []
+    },
+    {
       name: 'fix',
       boolean: true,
       color: chalk.blueBright,

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -87,11 +87,19 @@ const flags = [
     argName: '<path-to-elm>',
     usesEquals: false,
     color: chalk.cyan,
-    sections: ['regular', 'init'],
+    sections: ['regular', 'init', 'new-package'],
     description: [
       `Specify the path to the ${chalk.magentaBright('elm')} compiler.`
     ],
     initDescription: [
+      /* eslint-disable prettier/prettier */
+      `Specify the path to the ${chalk.magentaBright('elm')} compiler.`,
+      `The ${chalk.magentaBright('elm')} compiler is used to know the version of the compiler to write`,
+      `down in the ${chalk.yellowBright('review/elm.json')} file’s \`elm-version\` field. Use this if you`,
+      `have multiple versions of the ${chalk.magentaBright('elm')} compiler on your device.`
+      /* eslint-enable prettier/prettier */
+    ],
+    newPackageDescription: [
       /* eslint-disable prettier/prettier */
       `Specify the path to the ${chalk.magentaBright('elm')} compiler.`,
       `The ${chalk.magentaBright('elm')} compiler is used to know the version of the compiler to write`,
@@ -284,6 +292,8 @@ function preferredDescriptionFieldFor(subcommand) {
   switch (subcommand) {
     case 'init':
       return 'initDescription';
+    case 'new-package':
+      return 'newPackageDescription';
     default:
       return 'description';
   }

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -59,7 +59,7 @@ const flags = [
     argName: '<author>/<repo>[/path-to-the-config-folder][#branch-or-commit]',
     usesEquals: false,
     color: chalk.cyan,
-    sections: ['regular'],
+    sections: ['regular', 'init'],
     description: [
       /* eslint-disable prettier/prettier */
         'Use the review configuration from a GitHub repository. You can use this',
@@ -72,6 +72,13 @@ const flags = [
         `I recommend to only use this temporarily, and run ${chalk.yellowBright('elm-review init')} with`,
         'this same flag to copy the configuration to your project.',
         /* eslint-enable prettier/prettier */
+    ],
+    initDescription: [
+      'Copy the review configuration from a GitHub repository, at the root or',
+      'in a folder.',
+      'Examples:',
+      '- elm-review init --template author/elm-review-configuration',
+      '- elm-review init --template jfmengels/elm-review-unused/example#master'
     ]
   },
   {

--- a/lib/help.js
+++ b/lib/help.js
@@ -52,9 +52,7 @@ function init() {
 
 You can customize the init command with the following flags:
 
-    ${chalk.cyan('--config <path-to-review-directory>')}
-        Create the configuration files in the specified directory instead of in
-        the review/ directory.
+${Flags.buildFlags(Flags.flags.filter(flag => flag.section === 'init'))}
 
     ${chalk.cyan('--template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]')}
         Copy the review configuration from a GitHub repository, at the root or

--- a/lib/help.js
+++ b/lib/help.js
@@ -29,11 +29,11 @@ function review(options) {
 
 You can customize the review command with the following flags:
 
-${Flags.buildFlags(Flags.flags.filter(flag => flag.section === 'regular'))}
+${Flags.buildFlags('regular')}
 
 If you wish to use ${chalk.blueBright('automatic fixing')}, you can use the following flags:
 
-${Flags.buildFlags(Flags.flags.filter(flag => flag.section === 'fix'))}
+${Flags.buildFlags('fix')}
 `);
   /* eslint-enable prettier/prettier */
 }
@@ -52,7 +52,7 @@ function init() {
 
 You can customize the init command with the following flags:
 
-${Flags.buildFlags(Flags.flags.filter(flag => flag.section === 'init'))}
+${Flags.buildFlags('init')}
 
     ${chalk.cyan('--template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]')}
         Copy the review configuration from a GitHub repository, at the root or

--- a/lib/help.js
+++ b/lib/help.js
@@ -72,11 +72,7 @@ function newPackage() {
 
 You can customize the new-package command with the following flags:
 
-    ${chalk.cyan('--compiler <path-to-elm>')}
-        Specify the path to the ${chalk.magentaBright('elm')} compiler.
-        The ${chalk.magentaBright('elm')} compiler is used to know the version of the compiler to write
-        down in the ${chalk.yellowBright('review/elm.json')} file’s \`elm-version\` field. Use this if you
-        have multiple versions of the ${chalk.magentaBright('elm')} compiler on your device.
+${Flags.buildFlags({section: 'new-package', subcommand: 'new-package'})}
 `);
   /* eslint-enable prettier/prettier */
 }

--- a/lib/help.js
+++ b/lib/help.js
@@ -53,12 +53,6 @@ function init() {
 You can customize the init command with the following flags:
 
 ${Flags.buildFlags({section: 'init', subcommand: 'init'})}
-
-    ${chalk.cyan('--compiler <path-to-elm>')}
-        Specify the path to the ${chalk.magentaBright('elm')} compiler.
-        The ${chalk.magentaBright('elm')} compiler is used to know the version of the compiler to write
-        down in the ${chalk.yellowBright('review/elm.json')} file’s \`elm-version\` field. Use this if you
-        have multiple versions of the ${chalk.magentaBright('elm')} compiler on your device.
 `);
   /* eslint-enable prettier/prettier */
 }

--- a/lib/help.js
+++ b/lib/help.js
@@ -29,11 +29,11 @@ function review(options) {
 
 You can customize the review command with the following flags:
 
-${Flags.buildFlags('regular')}
+${Flags.buildFlags({section: 'regular'})}
 
 If you wish to use ${chalk.blueBright('automatic fixing')}, you can use the following flags:
 
-${Flags.buildFlags('fix')}
+${Flags.buildFlags({section: 'fix'})}
 `);
   /* eslint-enable prettier/prettier */
 }
@@ -52,7 +52,7 @@ function init() {
 
 You can customize the init command with the following flags:
 
-${Flags.buildFlags('init')}
+${Flags.buildFlags({section: 'init'})}
 
     ${chalk.cyan('--template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]')}
         Copy the review configuration from a GitHub repository, at the root or

--- a/lib/help.js
+++ b/lib/help.js
@@ -29,11 +29,11 @@ function review(options) {
 
 You can customize the review command with the following flags:
 
-${Flags.buildFlags(Flags.flags['*no subcommand*'].filter(flag => flag.section === 'regular'))}
+${Flags.buildFlags(Flags.flags.filter(flag => flag.section === 'regular'))}
 
 If you wish to use ${chalk.blueBright('automatic fixing')}, you can use the following flags:
 
-${Flags.buildFlags(Flags.flags['*no subcommand*'].filter(flag => flag.section === 'fix'))}
+${Flags.buildFlags(Flags.flags.filter(flag => flag.section === 'fix'))}
 `);
   /* eslint-enable prettier/prettier */
 }

--- a/lib/help.js
+++ b/lib/help.js
@@ -29,11 +29,11 @@ function review(options) {
 
 You can customize the review command with the following flags:
 
-${Flags.buildFlags({section: 'regular'})}
+${Flags.buildFlags({section: 'regular', subcommand: null})}
 
 If you wish to use ${chalk.blueBright('automatic fixing')}, you can use the following flags:
 
-${Flags.buildFlags({section: 'fix'})}
+${Flags.buildFlags({section: 'fix', subcommand: null})}
 `);
   /* eslint-enable prettier/prettier */
 }
@@ -52,7 +52,7 @@ function init() {
 
 You can customize the init command with the following flags:
 
-${Flags.buildFlags({section: 'init'})}
+${Flags.buildFlags({section: 'init', subcommand: 'init'})}
 
     ${chalk.cyan('--template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]')}
         Copy the review configuration from a GitHub repository, at the root or

--- a/lib/help.js
+++ b/lib/help.js
@@ -54,13 +54,6 @@ You can customize the init command with the following flags:
 
 ${Flags.buildFlags({section: 'init', subcommand: 'init'})}
 
-    ${chalk.cyan('--template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]')}
-        Copy the review configuration from a GitHub repository, at the root or
-        in a folder.
-        Examples:
-          - elm-review init --template author/elm-review-configuration
-          - elm-review init --template jfmengels/elm-review-unused/example#master
-
     ${chalk.cyan('--compiler <path-to-elm>')}
         Specify the path to the ${chalk.magentaBright('elm')} compiler.
         The ${chalk.magentaBright('elm')} compiler is used to know the version of the compiler to write

--- a/lib/options.js
+++ b/lib/options.js
@@ -312,6 +312,9 @@ function unknownShortHandFlagCheck(flag) {
   const flagRegex = /^-(?<name>\w+)/;
   const match = flagRegex.exec(flag);
 
+  if (!match) {
+    return true;
+  }
   // $FlowFixMe
   const flags = match.groups.name.split('');
   if (containsHelp || flags.includes('h')) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -230,6 +230,10 @@ path.relative(process.cwd(), 'elm.json')
 
 function parseTemplate(string) {
   const match = /([^/]+\/[^#/]+)(\/[^#]+)?(#(.+))?/.exec(string);
+  if(!match){
+    return null;
+  }
+
   // $FlowFixMe
   const [, repoName, pathToFolder, , reference] = match;
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -278,7 +278,7 @@ function unknownCheck() {
     const flagRegex = /^--(?<name>[^=]*)/;
     const match = flagRegex.exec(flag);
     if (!match) {
-      return true;
+      return unknownShortHandFlagCheck(flag);
     }
 
     // $FlowFixMe
@@ -304,6 +304,37 @@ function unknownCheck() {
 
     return true;
   };
+}
+
+function unknownShortHandFlagCheck(flag) {
+  const flagRegex = /^-(?<name>\w+)/;
+  const match = flagRegex.exec(flag);
+
+  // $FlowFixMe
+  const flags = match.groups.name.split('');
+  const aliases = Flags.flags.map((flag) => flag.alias).filter(Boolean);
+
+  flags.forEach((flag) => {
+    if (!aliases.includes(flag)) {
+      const errorToReport = new ErrorMessage.CustomError(
+        'UNKNOWN FLAG',
+        [
+          `I did not recognize this shorthand flag: ${chalk.redBright('-' + flag)}`,
+          '',
+          `I only know these: ${aliases
+            .sort()
+            .map((a) => chalk.greenBright('-' + a))
+            .join(', ')}`
+        ].join('\n')
+      );
+
+      console.log(ErrorMessage.report({}, errorToReport));
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(1);
+    }
+  });
+
+  return true;
 }
 
 function suggestions(flag) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -42,7 +42,7 @@ function compute(processArgv /* : Array<string> */) {
   });
 
   if (!containsHelp) {
-    checkForMissingArgs(args);
+    checkForMissingArgs(allFlags, args);
   }
 
   const subcommand =
@@ -293,8 +293,8 @@ function suggestions(flag) {
     .map((f) => chalk.greenBright(`    --${f.name}${Flags.buildFlagsArgs(f)}`));
 }
 
-function checkForMissingArgs(args) {
-  Flags.flags['*no subcommand*']
+function checkForMissingArgs(allFlags, args) {
+  allFlags
     .filter((flag) => flag.boolean === false)
     .forEach((flag) => {
       if (typeof args[flag.name] === 'boolean') {

--- a/lib/options.js
+++ b/lib/options.js
@@ -311,7 +311,7 @@ function checkForMissingArgs(subcommand, args) {
     .forEach((flag) => {
       if (typeof args[flag.name] === 'boolean') {
         const errorToReport = new ErrorMessage.CustomError(
-          'INVALID ARGUMENT',
+          'MISSING FLAG ARGUMENT',
           `The ${chalk.redBright(`--${flag.name}`)} flag needs more information.
 
 Here is the documentation for this flag:

--- a/lib/options.js
+++ b/lib/options.js
@@ -45,7 +45,7 @@ function compute(processArgv /* : Array<string> */) {
     availableSubcommands.find((subcmd) => subcmd === args._[0]) || null;
 
   if (!containsHelp) {
-    checkForMissingArgs(args);
+    checkForMissingArgs(subcommand, args);
   }
 
   const elmJsonPath = findElmJsonPath(args, subcommand);
@@ -298,7 +298,7 @@ function suggestions(flag) {
     .map((f) => chalk.greenBright(`    --${f.name}${Flags.buildFlagsArgs(f)}`));
 }
 
-function checkForMissingArgs(args) {
+function checkForMissingArgs(subcommand, args) {
   Flags.flags
     .filter((flag) => flag.boolean === false)
     .forEach((flag) => {

--- a/lib/options.js
+++ b/lib/options.js
@@ -102,7 +102,7 @@ path.relative(process.cwd(), 'elm.json')
       : path.join(projectToReview(), 'review');
   }
 
-  const template = args.template ? parseTemplate(args.template) : null;
+  const template = args.template ? parseTemplate(subcommand, args.template) : null;
 
   const forTests = args['FOR-TESTS'];
   const [gitHubUser, gitHubPassword] = args['github-auth']
@@ -228,10 +228,20 @@ path.relative(process.cwd(), 'elm.json')
   };
 }
 
-function parseTemplate(string) {
+function parseTemplate(subcommand, string) {
   const match = /([^/]+\/[^#/]+)(\/[^#]+)?(#(.+))?/.exec(string);
   if(!match){
-    return null;
+    const errorToReport = new ErrorMessage.CustomError(
+      'INVALID FLAG ARGUMENT',
+      `The value ${chalk.redBright(string)} passed to ${chalk.cyan('--template')} is not a valid one.
+
+Here is the documentation for this flag:
+
+${Flags.buildFlag(subcommand, Flags.flags.find(flag => flag.name==='template'))}`
+    );
+    console.log(ErrorMessage.report({}, errorToReport));
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
   }
 
   // $FlowFixMe

--- a/lib/options.js
+++ b/lib/options.js
@@ -27,27 +27,6 @@ function compute(processArgv /* : Array<string> */) {
 
   const allFlags = Object.values(Flags.flags).reduce((a, b) => [...a, ...b]);
 
-  const computed =  allFlags
-    .filter((flag) => flag.boolean)
-    .map((flag) => flag.name)
-  console.log();
-  console.log();
-  console.log();
-
-  console.log([
-    'version',
-    'help',
-    'debug',
-    'benchmark-info',
-    'details',
-    'fix',
-    'fix-all',
-    'fix-all-without-prompt',
-    'watch',
-    'ignore-problematic-dependencies',
-    'FOR-TESTS'
-  ].filter(f => !computed.includes(f)))
-
   const args = minimist(processArgv.slice(2), {
     alias: allFlags
       .filter((flag) => flag.alias)
@@ -55,19 +34,7 @@ function compute(processArgv /* : Array<string> */) {
         object[flag.name] == flag.alias;
         return object;
       }, {}),
-    boolean: [
-      'version',
-      'help',
-      'debug',
-      'benchmark-info',
-      'details',
-      'fix',
-      'fix-all',
-      'fix-all-without-prompt',
-      'watch',
-      'ignore-problematic-dependencies',
-      'FOR-TESTS'
-    ],
+    boolean: allFlags.filter((flag) => flag.boolean).map((flag) => flag.name),
     default: {
       details: true
     },

--- a/lib/options.js
+++ b/lib/options.js
@@ -46,6 +46,7 @@ function compute(processArgv /* : Array<string> */) {
 
   if (!containsHelp) {
     checkForMissingArgs(subcommand, args);
+    checkForInvalidArgs(subcommand, args);
   }
 
   const elmJsonPath = findElmJsonPath(args, subcommand);
@@ -324,6 +325,32 @@ ${Flags.buildFlag(subcommand, flag)}`
         process.exit(1);
       }
     });
+}
+
+function checkForInvalidArgs(subcommand, args) {
+  const errorToReport = checkForInvalidReportArg(subcommand,args);
+  if (!errorToReport) {
+    return;
+  }
+
+  console.log(ErrorMessage.report({}, errorToReport));
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit(1);
+}
+
+function checkForInvalidReportArg(subcommand, args) {
+  if (args.report
+    && !['json','ndjson','human'].includes(args.report)
+    ) {
+      return new ErrorMessage.CustomError(
+        'INVALID FLAG ARGUMENT',
+        `The value ${chalk.redBright(args.report)} passed to ${chalk.cyan('--report')} is not a valid one.
+
+Here is the documentation for this flag:
+
+${Flags.buildFlag(subcommand, Flags.flags.find(flag => flag.name==='report'))}`
+      );
+    }
 }
 
 module.exports = {

--- a/lib/options.js
+++ b/lib/options.js
@@ -25,24 +25,22 @@ function compute(processArgv /* : Array<string> */) {
     processArgv.slice(2).includes('--help') ||
     processArgv.slice(2).includes('-h');
 
-  const allFlags = Object.values(Flags.flags).reduce((a, b) => [...a, ...b]);
-
   const args = minimist(processArgv.slice(2), {
-    alias: allFlags
+    alias: Flags.flags
       .filter((flag) => flag.alias)
       .reduce((object, flag) => {
         object[flag.name] == flag.alias;
         return object;
       }, {}),
-    boolean: allFlags.filter((flag) => flag.boolean).map((flag) => flag.name),
+    boolean: Flags.flags.filter((flag) => flag.boolean).map((flag) => flag.name),
     default: {
       details: true
     },
-    unknown: containsHelp ? () => true : unknownCheck(allFlags)
+    unknown: containsHelp ? () => true : unknownCheck()
   });
 
   if (!containsHelp) {
-    checkForMissingArgs(allFlags, args);
+    checkForMissingArgs(args);
   }
 
   const subcommand =
@@ -249,8 +247,8 @@ function findElmJsonPath(args, subcommand) {
   return findUp.sync('elm.json');
 }
 
-function unknownCheck(allFlags) {
-  const allFlagNames = allFlags.map((flag) => flag.name);
+function unknownCheck() {
+  const allFlagNames = Flags.flags.map((flag) => flag.name);
 
   return (flag) => {
     if (flag.startsWith('--') && !allFlagNames.includes(flag.slice(2))) {
@@ -276,8 +274,7 @@ function unknownCheck(allFlags) {
 }
 
 function suggestions(flag) {
-  return Object.values(Flags.flags)
-    .reduce((a, b) => [...a, ...b])
+  return Flags.flags
     .map((f) => ({
       ...f,
       distance: levenshtein.get(flag, f.name)
@@ -297,8 +294,8 @@ function suggestions(flag) {
     .map((f) => chalk.greenBright(`    --${f.name}${Flags.buildFlagsArgs(f)}`));
 }
 
-function checkForMissingArgs(allFlags, args) {
-  allFlags
+function checkForMissingArgs(args) {
+  Flags.flags
     .filter((flag) => flag.boolean === false)
     .forEach((flag) => {
       if (typeof args[flag.name] === 'boolean') {

--- a/lib/options.js
+++ b/lib/options.js
@@ -309,7 +309,7 @@ function checkForMissingArgs(subcommand, args) {
 
 Here is the documentation for this flag:
 
-${Flags.buildFlag(flag)}`
+${Flags.buildFlag(subcommand, flag)}`
         );
 
         console.log(ErrorMessage.report({}, errorToReport));

--- a/lib/options.js
+++ b/lib/options.js
@@ -102,12 +102,14 @@ path.relative(process.cwd(), 'elm.json')
       : path.join(projectToReview(), 'review');
   }
 
-  const template = args.template ? parseTemplate(subcommand, args.template) : null;
+  const template = args.template
+    ? parseTemplate(subcommand, args.template)
+    : null;
 
   const forTests = args['FOR-TESTS'];
-  const [gitHubUser, gitHubPassword] = args['github-auth']
-    ? args['github-auth'].split(':')
-    : [undefined, undefined];
+  const {gitHubUser, gitHubPassword} = args['github-auth']
+    ? parseGitHubAuth(subcommand, args['github-auth'])
+    : {};
 
   const localElmReviewSrc = process.env.LOCAL_ELM_REVIEW_SRC;
 
@@ -230,14 +232,19 @@ path.relative(process.cwd(), 'elm.json')
 
 function parseTemplate(subcommand, string) {
   const match = /([^/]+\/[^#/]+)(\/[^#]+)?(#(.+))?/.exec(string);
-  if(!match){
+  if (!match) {
     const errorToReport = new ErrorMessage.CustomError(
       'INVALID FLAG ARGUMENT',
-      `The value ${chalk.redBright(string)} passed to ${chalk.cyan('--template')} is not a valid one.
+      `The value ${chalk.redBright(string)} passed to ${chalk.cyan(
+        '--template'
+      )} is not a valid one.
 
 Here is the documentation for this flag:
 
-${Flags.buildFlag(subcommand, Flags.flags.find(flag => flag.name==='template'))}`
+${Flags.buildFlag(
+  subcommand,
+  Flags.flags.find((flag) => flag.name === 'template')
+)}`
     );
     console.log(ErrorMessage.report({}, errorToReport));
     // eslint-disable-next-line unicorn/no-process-exit
@@ -342,7 +349,7 @@ ${Flags.buildFlag(subcommand, flag)}`
 }
 
 function checkForInvalidArgs(subcommand, args) {
-  const errorToReport = checkForInvalidReportArg(subcommand,args);
+  const errorToReport = checkForInvalidReportArg(subcommand, args);
   if (!errorToReport) {
     return;
   }
@@ -353,18 +360,46 @@ function checkForInvalidArgs(subcommand, args) {
 }
 
 function checkForInvalidReportArg(subcommand, args) {
-  if (args.report
-    && !['json','ndjson','human'].includes(args.report)
-    ) {
-      return new ErrorMessage.CustomError(
-        'INVALID FLAG ARGUMENT',
-        `The value ${chalk.redBright(args.report)} passed to ${chalk.cyan('--report')} is not a valid one.
+  if (args.report && !['json', 'ndjson', 'human'].includes(args.report)) {
+    return new ErrorMessage.CustomError(
+      'INVALID FLAG ARGUMENT',
+      `The value ${chalk.redBright(args.report)} passed to ${chalk.cyan(
+        '--report'
+      )} is not a valid one.
 
 Here is the documentation for this flag:
 
-${Flags.buildFlag(subcommand, Flags.flags.find(flag => flag.name==='report'))}`
-      );
-    }
+${Flags.buildFlag(
+  subcommand,
+  Flags.flags.find((flag) => flag.name === 'report')
+)}`
+    );
+  }
+}
+
+function parseGitHubAuth(subcommand, gitHubAuth) {
+  const split = gitHubAuth.split(':');
+  if (split.length !== 2) {
+    const errorToReport = new ErrorMessage.CustomError(
+      'INVALID FLAG ARGUMENT',
+      `The value ${chalk.redBright(gitHubAuth)} passed to ${chalk.cyan(
+        '--github-auth'
+      )} is not a valid one.
+
+Here is the documentation for this flag:
+
+${Flags.buildFlag(
+  subcommand,
+  Flags.flags.find((flag) => flag.name === 'github-auth')
+)}`
+    );
+    console.log(ErrorMessage.report({}, errorToReport));
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  }
+
+  const [gitHubUser, gitHubPassword] = split;
+  return {gitHubUser, gitHubPassword};
 }
 
 module.exports = {

--- a/lib/options.js
+++ b/lib/options.js
@@ -19,6 +19,12 @@ course of action is and how to get forward.
  */
 
 const availableSubcommands = ['init', 'new-package', 'new-rule'];
+const aliases = Flags.flags
+  .filter((flag) => flag.alias)
+  .reduce((object, flag) => {
+    object[flag.name] = flag.alias;
+    return object;
+  }, {});
 
 function compute(processArgv /* : Array<string> */) {
   const containsHelp =
@@ -26,12 +32,7 @@ function compute(processArgv /* : Array<string> */) {
     processArgv.slice(2).includes('-h');
 
   const args = minimist(processArgv.slice(2), {
-    alias: Flags.flags
-      .filter((flag) => flag.alias)
-      .reduce((object, flag) => {
-        object[flag.name] = flag.alias;
-        return object;
-      }, {}),
+    alias: aliases,
     boolean: Flags.flags
       .filter((flag) => flag.boolean)
       .map((flag) => flag.name),

--- a/lib/options.js
+++ b/lib/options.js
@@ -315,12 +315,14 @@ function unknownShortHandFlagCheck(flag) {
   if (!match) {
     return true;
   }
+
   // $FlowFixMe
   const flags = match.groups.name.split('');
   if (containsHelp || flags.includes('h')) {
     containsHelp = true;
     return true;
   }
+
   const aliases = Flags.flags.map((flag) => flag.alias).filter(Boolean);
 
   flags.forEach((flag) => {
@@ -328,7 +330,9 @@ function unknownShortHandFlagCheck(flag) {
       const errorToReport = new ErrorMessage.CustomError(
         'UNKNOWN FLAG',
         [
-          `I did not recognize this shorthand flag: ${chalk.redBright('-' + flag)}`,
+          `I did not recognize this shorthand flag: ${chalk.redBright(
+            '-' + flag
+          )}`,
           '',
           `I only know these: ${aliases
             .sort()

--- a/lib/options.js
+++ b/lib/options.js
@@ -27,6 +27,27 @@ function compute(processArgv /* : Array<string> */) {
 
   const allFlags = Object.values(Flags.flags).reduce((a, b) => [...a, ...b]);
 
+  const computed =  allFlags
+    .filter((flag) => flag.boolean)
+    .map((flag) => flag.name)
+  console.log();
+  console.log();
+  console.log();
+
+  console.log([
+    'version',
+    'help',
+    'debug',
+    'benchmark-info',
+    'details',
+    'fix',
+    'fix-all',
+    'fix-all-without-prompt',
+    'watch',
+    'ignore-problematic-dependencies',
+    'FOR-TESTS'
+  ].filter(f => !computed.includes(f)))
+
   const args = minimist(processArgv.slice(2), {
     alias: allFlags
       .filter((flag) => flag.alias)

--- a/lib/options.js
+++ b/lib/options.js
@@ -38,7 +38,7 @@ function compute(processArgv /* : Array<string> */) {
     default: {
       details: true
     },
-    unknown: containsHelp ? () => true : unknownCheck
+    unknown: containsHelp ? () => true : unknownCheck(allFlags)
   });
 
   if (!containsHelp) {
@@ -249,26 +249,30 @@ function findElmJsonPath(args, subcommand) {
   return findUp.sync('elm.json');
 }
 
-function unknownCheck(flag) {
-  if (flag.startsWith('--')) {
-    const errorToReport = new ErrorMessage.CustomError(
-      'UNKNOWN FLAG',
-      [
-        'I did not recognize this flag:',
-        '',
-        `    ${chalk.redBright(flag)}`,
-        '',
-        'Maybe you want one of these instead?',
-        '',
-        ...suggestions(flag)
-      ].join('\n')
-    );
+function unknownCheck(allFlags) {
+  const allFlagNames = allFlags.map((flag) => flag.name);
 
-    console.log(ErrorMessage.report({}, errorToReport));
-    process.exit(1);
-  }
+  return (flag) => {
+    if (flag.startsWith('--') && !allFlagNames.includes(flag.slice(2))) {
+      const errorToReport = new ErrorMessage.CustomError(
+        'UNKNOWN FLAG',
+        [
+          'I did not recognize this flag:',
+          '',
+          `    ${chalk.redBright(flag)}`,
+          '',
+          'Maybe you want one of these instead?',
+          '',
+          ...suggestions(flag)
+        ].join('\n')
+      );
 
-  return true;
+      console.log(ErrorMessage.report({}, errorToReport));
+      process.exit(1);
+    }
+
+    return true;
+  };
 }
 
 function suggestions(flag) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -41,12 +41,12 @@ function compute(processArgv /* : Array<string> */) {
     unknown: containsHelp ? () => true : unknownCheck()
   });
 
+  const subcommand =
+    availableSubcommands.find((subcmd) => subcmd === args._[0]) || null;
+
   if (!containsHelp) {
     checkForMissingArgs(args);
   }
-
-  const subcommand =
-    availableSubcommands.find((subcmd) => subcmd === args._[0]) || null;
 
   const elmJsonPath = findElmJsonPath(args, subcommand);
   const readmePath =

--- a/lib/options.js
+++ b/lib/options.js
@@ -235,7 +235,7 @@ path.relative(process.cwd(), 'elm.json')
 function parseTemplate(subcommand, string) {
   const match = /([^/]+\/[^#/]+)(\/[^#]+)?(#(.+))?/.exec(string);
   if (!match) {
-    const errorToReport = new ErrorMessage.CustomError(
+    reportErrorAndExit(new ErrorMessage.CustomError(
       'INVALID FLAG ARGUMENT',
       `The value ${chalk.redBright(string)} passed to ${chalk.cyan(
         '--template'
@@ -247,10 +247,7 @@ ${Flags.buildFlag(
   subcommand,
   Flags.flags.find((flag) => flag.name === 'template')
 )}`
-    );
-    console.log(ErrorMessage.report({}, errorToReport));
-    // eslint-disable-next-line unicorn/no-process-exit
-    process.exit(1);
+    ));
   }
 
   // $FlowFixMe
@@ -286,7 +283,7 @@ function unknownCheck() {
     // $FlowFixMe
     const {name} = match.groups;
     if (!allFlagNames.has(name)) {
-      const errorToReport = new ErrorMessage.CustomError(
+      reportErrorAndExit(new ErrorMessage.CustomError(
         'UNKNOWN FLAG',
         [
           'I did not recognize this flag:',
@@ -297,11 +294,7 @@ function unknownCheck() {
           '',
           ...suggestions(name)
         ].join('\n')
-      );
-
-      console.log(ErrorMessage.report({}, errorToReport));
-      // eslint-disable-next-line unicorn/no-process-exit
-      process.exit(1);
+      ));
     }
 
     return true;
@@ -327,7 +320,7 @@ function unknownShortHandFlagCheck(flag) {
 
   flags.forEach((flag) => {
     if (!aliases.includes(flag)) {
-      const errorToReport = new ErrorMessage.CustomError(
+      reportErrorAndExit(new ErrorMessage.CustomError(
         'UNKNOWN FLAG',
         [
           `I did not recognize this shorthand flag: ${chalk.redBright(
@@ -339,11 +332,7 @@ function unknownShortHandFlagCheck(flag) {
             .map((a) => chalk.greenBright('-' + a))
             .join(', ')}`
         ].join('\n')
-      );
-
-      console.log(ErrorMessage.report({}, errorToReport));
-      // eslint-disable-next-line unicorn/no-process-exit
-      process.exit(1);
+      ));
     }
   });
 
@@ -376,36 +365,21 @@ function checkForMissingArgs(subcommand, args) {
     .filter((flag) => flag.boolean === false)
     .forEach((flag) => {
       if (typeof args[flag.name] === 'boolean') {
-        const errorToReport = new ErrorMessage.CustomError(
+        reportErrorAndExit(new ErrorMessage.CustomError(
           'MISSING FLAG ARGUMENT',
           `The ${chalk.redBright(`--${flag.name}`)} flag needs more information.
 
 Here is the documentation for this flag:
 
 ${Flags.buildFlag(subcommand, flag)}`
-        );
-
-        console.log(ErrorMessage.report({}, errorToReport));
-        // eslint-disable-next-line unicorn/no-process-exit
-        process.exit(1);
+        ));
       }
     });
 }
 
 function checkForInvalidArgs(subcommand, args) {
-  const errorToReport = checkForInvalidReportArg(subcommand, args);
-  if (!errorToReport) {
-    return;
-  }
-
-  console.log(ErrorMessage.report({}, errorToReport));
-  // eslint-disable-next-line unicorn/no-process-exit
-  process.exit(1);
-}
-
-function checkForInvalidReportArg(subcommand, args) {
   if (args.report && !['json', 'ndjson', 'human'].includes(args.report)) {
-    return new ErrorMessage.CustomError(
+    reportErrorAndExit(new ErrorMessage.CustomError(
       'INVALID FLAG ARGUMENT',
       `The value ${chalk.redBright(args.report)} passed to ${chalk.cyan(
         '--report'
@@ -417,14 +391,14 @@ ${Flags.buildFlag(
   subcommand,
   Flags.flags.find((flag) => flag.name === 'report')
 )}`
-    );
+    ));
   }
 }
 
 function parseGitHubAuth(subcommand, gitHubAuth) {
   const split = gitHubAuth.split(':');
   if (split.length !== 2) {
-    const errorToReport = new ErrorMessage.CustomError(
+    reportErrorAndExit(new ErrorMessage.CustomError(
       'INVALID FLAG ARGUMENT',
       `The value ${chalk.redBright(gitHubAuth)} passed to ${chalk.cyan(
         '--github-auth'
@@ -436,14 +410,17 @@ ${Flags.buildFlag(
   subcommand,
   Flags.flags.find((flag) => flag.name === 'github-auth')
 )}`
-    );
-    console.log(ErrorMessage.report({}, errorToReport));
-    // eslint-disable-next-line unicorn/no-process-exit
-    process.exit(1);
+    ));
   }
 
   const [gitHubUser, gitHubPassword] = split;
   return {gitHubUser, gitHubPassword};
+}
+
+function reportErrorAndExit(errorToReport) {
+  console.log(ErrorMessage.report({}, errorToReport));
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit(1);
 }
 
 module.exports = {

--- a/lib/options.js
+++ b/lib/options.js
@@ -20,8 +20,10 @@ course of action is and how to get forward.
 
 const availableSubcommands = ['init', 'new-package', 'new-rule'];
 
+let containsHelp = false;
+
 function compute(processArgv /* : Array<string> */) {
-  const containsHelp =
+  containsHelp =
     processArgv.slice(2).includes('--help') ||
     processArgv.slice(2).includes('-h');
 
@@ -277,7 +279,7 @@ function unknownCheck() {
   return (flag) => {
     const flagRegex = /^--(?<name>[^=]*)/;
     const match = flagRegex.exec(flag);
-    if (!match) {
+    if (containsHelp || !match) {
       return unknownShortHandFlagCheck(flag);
     }
 
@@ -312,7 +314,8 @@ function unknownShortHandFlagCheck(flag) {
 
   // $FlowFixMe
   const flags = match.groups.name.split('');
-  if (flags.includes('h')) {
+  if (containsHelp || flags.includes('h')) {
+    containsHelp = true;
     return true;
   }
   const aliases = Flags.flags.map((flag) => flag.alias).filter(Boolean);

--- a/lib/options.js
+++ b/lib/options.js
@@ -19,12 +19,6 @@ course of action is and how to get forward.
  */
 
 const availableSubcommands = ['init', 'new-package', 'new-rule'];
-const aliases = Flags.flags
-  .filter((flag) => flag.alias)
-  .reduce((object, flag) => {
-    object[flag.name] = flag.alias;
-    return object;
-  }, {});
 
 function compute(processArgv /* : Array<string> */) {
   const containsHelp =
@@ -32,7 +26,12 @@ function compute(processArgv /* : Array<string> */) {
     processArgv.slice(2).includes('-h');
 
   const args = minimist(processArgv.slice(2), {
-    alias: aliases,
+    alias: Flags.flags
+      .filter((flag) => flag.alias)
+      .reduce((object, flag) => {
+        object[flag.name] = flag.alias;
+        return object;
+      }, {}),
     boolean: Flags.flags
       .filter((flag) => flag.boolean)
       .map((flag) => flag.name),

--- a/lib/options.js
+++ b/lib/options.js
@@ -297,7 +297,7 @@ function suggestions(flag) {
       return 0;
     })
     .slice(0, 2)
-    .map((f) => chalk.greenBright(`    --${f.name}`));
+    .map((f) => chalk.greenBright(`    --${f.name}${Flags.buildFlagsArgs(f)}`));
 }
 
 function checkForMissingArgs(args) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -275,8 +275,8 @@ function unknownCheck() {
   const allFlagNames = new Set(Flags.flags.map((flag) => flag.name));
 
   return (flag) => {
-    const regex = /^--(?<name>[^=]*)/;
-    const match = regex.exec(flag);
+    const flagRegex = /^--(?<name>[^=]*)/;
+    const match = flagRegex.exec(flag);
     if (!match) {
       return true;
     }

--- a/lib/options.js
+++ b/lib/options.js
@@ -312,6 +312,9 @@ function unknownShortHandFlagCheck(flag) {
 
   // $FlowFixMe
   const flags = match.groups.name.split('');
+  if (flags.includes('h')) {
+    return true;
+  }
   const aliases = Flags.flags.map((flag) => flag.alias).filter(Boolean);
 
   flags.forEach((flag) => {

--- a/lib/options.js
+++ b/lib/options.js
@@ -303,7 +303,7 @@ function checkForMissingArgs(args) {
           'INVALID ARGUMENT',
           `The ${chalk.redBright(`--${flag.name}`)} flag needs more information.
 
-  It needs ${flag.whatItNeeds} like:
+It needs ${flag.whatItNeeds} like:
 
     ${chalk.greenBright(`--${flag.name}${Flags.buildFlagsArgs(flag)}`)}`
         );

--- a/lib/options.js
+++ b/lib/options.js
@@ -307,9 +307,9 @@ function checkForMissingArgs(args) {
           'INVALID ARGUMENT',
           `The ${chalk.redBright(`--${flag.name}`)} flag needs more information.
 
-It needs ${flag.whatItNeeds} like:
+Here is the documentation for this flag:
 
-    ${chalk.greenBright(`--${flag.name}${Flags.buildFlagsArgs(flag)}`)}`
+${Flags.buildFlag(flag)}`
         );
 
         console.log(ErrorMessage.report({}, errorToReport));

--- a/lib/options.js
+++ b/lib/options.js
@@ -32,7 +32,9 @@ function compute(processArgv /* : Array<string> */) {
         object[flag.name] = flag.alias;
         return object;
       }, {}),
-    boolean: Flags.flags.filter((flag) => flag.boolean).map((flag) => flag.name),
+    boolean: Flags.flags
+      .filter((flag) => flag.boolean)
+      .map((flag) => flag.name),
     default: {
       details: true
     },
@@ -248,20 +250,22 @@ function findElmJsonPath(args, subcommand) {
 }
 
 function unknownCheck() {
-  const allFlagNames = Flags.flags.map((flag) => flag.name);
+  const allFlagNames = new Set(Flags.flags.map((flag) => flag.name));
 
   return (flag) => {
-    if (flag.startsWith('--') && !allFlagNames.includes(flag.slice(2))) {
+    const regex = /^--(?<name>[^=]*)/;
+    const match = regex.exec(flag);
+    if (match && !allFlagNames.has(match.groups.name)) {
       const errorToReport = new ErrorMessage.CustomError(
         'UNKNOWN FLAG',
         [
           'I did not recognize this flag:',
           '',
-          `    ${chalk.redBright(flag)}`,
+          `    ${chalk.redBright(match.groups.name)}`,
           '',
           'Maybe you want one of these instead?',
           '',
-          ...suggestions(flag)
+          ...suggestions(match.groups.name)
         ].join('\n')
       );
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -29,7 +29,7 @@ function compute(processArgv /* : Array<string> */) {
     alias: Flags.flags
       .filter((flag) => flag.alias)
       .reduce((object, flag) => {
-        object[flag.name] == flag.alias;
+        object[flag.name] = flag.alias;
         return object;
       }, {}),
     boolean: Flags.flags.filter((flag) => flag.boolean).map((flag) => flag.name),

--- a/lib/options.js
+++ b/lib/options.js
@@ -235,11 +235,12 @@ path.relative(process.cwd(), 'elm.json')
 function parseTemplate(subcommand, string) {
   const match = /([^/]+\/[^#/]+)(\/[^#]+)?(#(.+))?/.exec(string);
   if (!match) {
-    reportErrorAndExit(new ErrorMessage.CustomError(
-      'INVALID FLAG ARGUMENT',
-      `The value ${chalk.redBright(string)} passed to ${chalk.cyan(
-        '--template'
-      )} is not a valid one.
+    reportErrorAndExit(
+      new ErrorMessage.CustomError(
+        'INVALID FLAG ARGUMENT',
+        `The value ${chalk.redBright(string)} passed to ${chalk.cyan(
+          '--template'
+        )} is not a valid one.
 
 Here is the documentation for this flag:
 
@@ -247,7 +248,8 @@ ${Flags.buildFlag(
   subcommand,
   Flags.flags.find((flag) => flag.name === 'template')
 )}`
-    ));
+      )
+    );
   }
 
   // $FlowFixMe
@@ -283,18 +285,20 @@ function unknownCheck() {
     // $FlowFixMe
     const {name} = match.groups;
     if (!allFlagNames.has(name)) {
-      reportErrorAndExit(new ErrorMessage.CustomError(
-        'UNKNOWN FLAG',
-        [
-          'I did not recognize this flag:',
-          '',
-          `    ${chalk.redBright(name)}`,
-          '',
-          'Maybe you want one of these instead?',
-          '',
-          ...suggestions(name)
-        ].join('\n')
-      ));
+      reportErrorAndExit(
+        new ErrorMessage.CustomError(
+          'UNKNOWN FLAG',
+          [
+            'I did not recognize this flag:',
+            '',
+            `    ${chalk.redBright(name)}`,
+            '',
+            'Maybe you want one of these instead?',
+            '',
+            ...suggestions(name)
+          ].join('\n')
+        )
+      );
     }
 
     return true;
@@ -320,19 +324,21 @@ function unknownShortHandFlagCheck(flag) {
 
   flags.forEach((flag) => {
     if (!aliases.includes(flag)) {
-      reportErrorAndExit(new ErrorMessage.CustomError(
-        'UNKNOWN FLAG',
-        [
-          `I did not recognize this shorthand flag: ${chalk.redBright(
-            '-' + flag
-          )}`,
-          '',
-          `I only know these: ${aliases
-            .sort()
-            .map((a) => chalk.greenBright('-' + a))
-            .join(', ')}`
-        ].join('\n')
-      ));
+      reportErrorAndExit(
+        new ErrorMessage.CustomError(
+          'UNKNOWN FLAG',
+          [
+            `I did not recognize this shorthand flag: ${chalk.redBright(
+              '-' + flag
+            )}`,
+            '',
+            `I only know these: ${aliases
+              .sort()
+              .map((a) => chalk.greenBright('-' + a))
+              .join(', ')}`
+          ].join('\n')
+        )
+      );
     }
   });
 
@@ -365,25 +371,30 @@ function checkForMissingArgs(subcommand, args) {
     .filter((flag) => flag.boolean === false)
     .forEach((flag) => {
       if (typeof args[flag.name] === 'boolean') {
-        reportErrorAndExit(new ErrorMessage.CustomError(
-          'MISSING FLAG ARGUMENT',
-          `The ${chalk.redBright(`--${flag.name}`)} flag needs more information.
+        reportErrorAndExit(
+          new ErrorMessage.CustomError(
+            'MISSING FLAG ARGUMENT',
+            `The ${chalk.redBright(
+              `--${flag.name}`
+            )} flag needs more information.
 
 Here is the documentation for this flag:
 
 ${Flags.buildFlag(subcommand, flag)}`
-        ));
+          )
+        );
       }
     });
 }
 
 function checkForInvalidArgs(subcommand, args) {
   if (args.report && !['json', 'ndjson', 'human'].includes(args.report)) {
-    reportErrorAndExit(new ErrorMessage.CustomError(
-      'INVALID FLAG ARGUMENT',
-      `The value ${chalk.redBright(args.report)} passed to ${chalk.cyan(
-        '--report'
-      )} is not a valid one.
+    reportErrorAndExit(
+      new ErrorMessage.CustomError(
+        'INVALID FLAG ARGUMENT',
+        `The value ${chalk.redBright(args.report)} passed to ${chalk.cyan(
+          '--report'
+        )} is not a valid one.
 
 Here is the documentation for this flag:
 
@@ -391,18 +402,20 @@ ${Flags.buildFlag(
   subcommand,
   Flags.flags.find((flag) => flag.name === 'report')
 )}`
-    ));
+      )
+    );
   }
 }
 
 function parseGitHubAuth(subcommand, gitHubAuth) {
   const split = gitHubAuth.split(':');
   if (split.length !== 2) {
-    reportErrorAndExit(new ErrorMessage.CustomError(
-      'INVALID FLAG ARGUMENT',
-      `The value ${chalk.redBright(gitHubAuth)} passed to ${chalk.cyan(
-        '--github-auth'
-      )} is not a valid one.
+    reportErrorAndExit(
+      new ErrorMessage.CustomError(
+        'INVALID FLAG ARGUMENT',
+        `The value ${chalk.redBright(gitHubAuth)} passed to ${chalk.cyan(
+          '--github-auth'
+        )} is not a valid one.
 
 Here is the documentation for this flag:
 
@@ -410,7 +423,8 @@ ${Flags.buildFlag(
   subcommand,
   Flags.flags.find((flag) => flag.name === 'github-auth')
 )}`
-    ));
+      )
+    );
   }
 
   const [gitHubUser, gitHubPassword] = split;

--- a/lib/options.js
+++ b/lib/options.js
@@ -282,7 +282,7 @@ function suggestions(flag) {
   return Object.values(Flags.flags)
     .reduce((a, b) => [...a, ...b])
     .map((f) => ({
-      name: f.name,
+      ...f,
       distance: levenshtein.get(flag, f.name)
     }))
     .sort((a, b) => {

--- a/lib/options.js
+++ b/lib/options.js
@@ -24,11 +24,16 @@ function compute(processArgv /* : Array<string> */) {
   const containsHelp =
     processArgv.slice(2).includes('--help') ||
     processArgv.slice(2).includes('-h');
+
+  const allFlags = Object.values(Flags.flags).reduce((a, b) => [...a, ...b]);
+
   const args = minimist(processArgv.slice(2), {
-    alias: {
-      help: 'h',
-      version: 'v'
-    },
+    alias: allFlags
+      .filter((flag) => flag.alias)
+      .reduce((object, flag) => {
+        object[flag.name] == flag.alias;
+        return object;
+      }, {}),
     boolean: [
       'version',
       'help',

--- a/lib/options.js
+++ b/lib/options.js
@@ -255,17 +255,23 @@ function unknownCheck() {
   return (flag) => {
     const regex = /^--(?<name>[^=]*)/;
     const match = regex.exec(flag);
-    if (match && !allFlagNames.has(match.groups.name)) {
+    if (!match) {
+      return true;
+    }
+
+    // $FlowFixMe
+    const {name} = match.groups;
+    if (!allFlagNames.has(name)) {
       const errorToReport = new ErrorMessage.CustomError(
         'UNKNOWN FLAG',
         [
           'I did not recognize this flag:',
           '',
-          `    ${chalk.redBright(match.groups.name)}`,
+          `    ${chalk.redBright(name)}`,
           '',
           'Maybe you want one of these instead?',
           '',
-          ...suggestions(match.groups.name)
+          ...suggestions(name)
         ].join('\n')
       );
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -270,6 +270,7 @@ function unknownCheck() {
       );
 
       console.log(ErrorMessage.report({}, errorToReport));
+      // eslint-disable-next-line unicorn/no-process-exit
       process.exit(1);
     }
 
@@ -313,6 +314,7 @@ ${Flags.buildFlag(subcommand, flag)}`
         );
 
         console.log(ErrorMessage.report({}, errorToReport));
+        // eslint-disable-next-line unicorn/no-process-exit
         process.exit(1);
       }
     });

--- a/lib/options.js
+++ b/lib/options.js
@@ -21,7 +21,9 @@ course of action is and how to get forward.
 const availableSubcommands = ['init', 'new-package', 'new-rule'];
 
 function compute(processArgv /* : Array<string> */) {
-  const containsHelp = processArgv.slice(2).includes('--help') || processArgv.slice(2).includes('-h')
+  const containsHelp =
+    processArgv.slice(2).includes('--help') ||
+    processArgv.slice(2).includes('-h');
   const args = minimist(processArgv.slice(2), {
     alias: {
       help: 'h',
@@ -254,28 +256,6 @@ function findElmJsonPath(args, subcommand) {
   return findUp.sync('elm.json');
 }
 
-function suggestions(flag) {
-  return Object.values(Flags.flags)
-    .reduce((a, b) => [...a, ...b])
-    .map((f) => ({
-      name: f.name,
-      distance: levenshtein.get(flag, f.name)
-    }))
-    .sort((a, b) => {
-      if (a.distance < b.distance) {
-        return -1;
-      }
-
-      if (a.distance > b.distance) {
-        return 1;
-      }
-
-      return 0;
-    })
-    .slice(0, 2)
-    .map((f) => chalk.greenBright(`    --${f.name}`));
-}
-
 function unknownCheck(flag) {
   if (flag.startsWith('--')) {
     const errorToReport = new ErrorMessage.CustomError(
@@ -298,6 +278,27 @@ function unknownCheck(flag) {
   return true;
 }
 
+function suggestions(flag) {
+  return Object.values(Flags.flags)
+    .reduce((a, b) => [...a, ...b])
+    .map((f) => ({
+      name: f.name,
+      distance: levenshtein.get(flag, f.name)
+    }))
+    .sort((a, b) => {
+      if (a.distance < b.distance) {
+        return -1;
+      }
+
+      if (a.distance > b.distance) {
+        return 1;
+      }
+
+      return 0;
+    })
+    .slice(0, 2)
+    .map((f) => chalk.greenBright(`    --${f.name}`));
+}
 
 function checkForMissingArgs(args) {
   Flags.flags['*no subcommand*']

--- a/test/run.sh
+++ b/test/run.sh
@@ -245,12 +245,12 @@ $createTest "$CMD" \
     "report-unknown-argument.txt"
 
 $createTest "$CMD" \
-    "Running --template with an bad value" \
+    "Running --template with a bad value" \
     "--template=not-github-repo" \
     "template-bad-argument.txt"
 
 $createTest "$CMD" \
-    "Running init --template with an bad value" \
+    "Running init --template with a bad value" \
     "init --template=not-github-repo" \
     "init-template-bad-argument.txt"
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -235,6 +235,11 @@ $createTest "$CMD" \
     "missing-argument-new-package-compiler.txt"
 
 $createTest "$CMD" \
+    "Running --github-auth with a bad value" \
+    "--github-auth=bad" \
+    "github-auth-bad-argument.txt"
+
+$createTest "$CMD" \
     "Running --report with an unknown value" \
     "--report=unknown" \
     "report-unknown-argument.txt"

--- a/test/run.sh
+++ b/test/run.sh
@@ -216,22 +216,22 @@ $createTest "$CMD" \
 
 $createTest "$CMD" \
     "Running init --compiler without an argument" \
-    "--compiler" \
+    "init --compiler" \
     "missing-argument-init-compiler.txt"
 
 $createTest "$CMD" \
     "Running init --config without an argument" \
-    "--config" \
+    "init --config" \
     "missing-argument-init-config.txt"
 
 $createTest "$CMD" \
     "Running init --template without an argument" \
-    "--template" \
+    "init --template" \
     "missing-argument-init-template.txt"
 
 $createTest "$CMD" \
     "Running new-package --compiler without an argument" \
-    "--compiler" \
+    "new-package --compiler" \
     "missing-argument-new-package-compiler.txt"
 
 # init

--- a/test/run.sh
+++ b/test/run.sh
@@ -181,7 +181,7 @@ $createTest "$CMD" \
 
 $createTest "$CMD" \
     "Running with an unknown flag" \
-    "--unknown" \
+    "--watc" \
     "unknown-flag.txt"
 
 $createTest "$CMD" \

--- a/test/run.sh
+++ b/test/run.sh
@@ -177,6 +177,13 @@ $createTest "$CMD" \
     "new-rule --help" \
     "help-new-rule.txt"
 
+# Unknown flags
+
+$createTest "$CMD" \
+    "Running with an unknown flag" \
+    "--unknown" \
+    "unknown-flag.txt"
+
 # Flag errors
 
 $createTest "$CMD" \

--- a/test/run.sh
+++ b/test/run.sh
@@ -239,6 +239,16 @@ $createTest "$CMD" \
     "--report=unknown" \
     "report-unknown-argument.txt"
 
+$createTest "$CMD" \
+    "Running --template with an bad value" \
+    "--template=not-github-repo" \
+    "template-bad-argument.txt"
+
+$createTest "$CMD" \
+    "Running init --template with an bad value" \
+    "init --template=not-github-repo" \
+    "init-template-bad-argument.txt"
+
 # init
 
 INIT_PROJECT_NAME="init-project"

--- a/test/run.sh
+++ b/test/run.sh
@@ -234,10 +234,14 @@ $createTest "$CMD" \
     "new-package --compiler" \
     "missing-argument-new-package-compiler.txt"
 
+# Temporarily disabling auth because otherwise `--github-auth` would be duplicated
+OLD_AUTH="$AUTH"
+AUTH=""
 $createTest "$CMD" \
     "Running --github-auth with a bad value" \
     "--github-auth=bad" \
     "github-auth-bad-argument.txt"
+AUTH="$OLD_AUTH"
 
 $createTest "$CMD" \
     "Running --report with an unknown value" \

--- a/test/run.sh
+++ b/test/run.sh
@@ -184,6 +184,11 @@ $createTest "$CMD" \
     "--unknown" \
     "unknown-flag.txt"
 
+$createTest "$CMD" \
+    "Running with an unknown shorthand flag" \
+    "-u" \
+    "unknown-shorthand-flag.txt"
+
 # Flag errors
 
 $createTest "$CMD" \

--- a/test/run.sh
+++ b/test/run.sh
@@ -234,6 +234,11 @@ $createTest "$CMD" \
     "new-package --compiler" \
     "missing-argument-new-package-compiler.txt"
 
+$createTest "$CMD" \
+    "Running --report with an unknown value" \
+    "--report=unknown" \
+    "report-unknown-argument.txt"
+
 # init
 
 INIT_PROJECT_NAME="init-project"

--- a/test/snapshots/github-auth-bad-argument.txt
+++ b/test/snapshots/github-auth-bad-argument.txt
@@ -1,0 +1,13 @@
+-- INVALID FLAG ARGUMENT -------------------------------------------------------
+
+The value bad passed to --github-auth is not a valid one.
+
+Here is the documentation for this flag:
+
+    --github-auth=<github-api-token>
+        To be used along with --template to avoid GitHub rate limiting.
+        Follow https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token. The API token needs access to public repositories.
+
+        Then use the flag like this:
+          --github-auth=my-user-name:abcdef01234567890
+

--- a/test/snapshots/help-main.txt
+++ b/test/snapshots/help-main.txt
@@ -62,7 +62,7 @@ You can customize the review command with the following flags:
         - Run the compiler in debug mode, allowing you to use Debug statements
           in your configuration and custom rules.
 
-    --report=json, --report=ndjson
+    --report=<json or ndjson>
         Error reports will be in JSON format. json prints a single JSON object
         while ndjson will print one JSON object per error each on a new line.
         The formats are described in this document: https://bit.ly/31F6jzz

--- a/test/snapshots/init-template-bad-argument.txt
+++ b/test/snapshots/init-template-bad-argument.txt
@@ -1,0 +1,13 @@
+-- INVALID FLAG ARGUMENT -------------------------------------------------------
+
+The value not-github-repo passed to --template is not a valid one.
+
+Here is the documentation for this flag:
+
+    --template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]
+        Copy the review configuration from a GitHub repository, at the root or
+        in a folder.
+        Examples:
+          - elm-review init --template author/elm-review-configuration
+          - elm-review init --template jfmengels/elm-review-unused/example#master
+

--- a/test/snapshots/missing-argument-compiler.txt
+++ b/test/snapshots/missing-argument-compiler.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --compiler flag needs more information.
 

--- a/test/snapshots/missing-argument-compiler.txt
+++ b/test/snapshots/missing-argument-compiler.txt
@@ -2,7 +2,8 @@
 
 The --compiler flag needs more information.
 
-It needs the path to the Elm binary like:
+Here is the documentation for this flag:
 
     --compiler <path-to-elm>
+        Specify the path to the elm compiler.
 

--- a/test/snapshots/missing-argument-compiler.txt
+++ b/test/snapshots/missing-argument-compiler.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --compiler flag needs more information.
+
+It needs the path to the Elm binary like:
+
+    --compiler <path-to-elm>
+

--- a/test/snapshots/missing-argument-config.txt
+++ b/test/snapshots/missing-argument-config.txt
@@ -2,7 +2,9 @@
 
 The --config flag needs more information.
 
-It needs the path to the review configuration directory like:
+Here is the documentation for this flag:
 
     --config <path-to-review-directory>
+        Use the review configuration in the specified directory instead of the
+        one found in the current directory or one of its parents.
 

--- a/test/snapshots/missing-argument-config.txt
+++ b/test/snapshots/missing-argument-config.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --config flag needs more information.
 

--- a/test/snapshots/missing-argument-config.txt
+++ b/test/snapshots/missing-argument-config.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --config flag needs more information.
+
+It needs the path to the review configuration directory like:
+
+    --config <path-to-review-directory>
+

--- a/test/snapshots/missing-argument-elm-format-path.txt
+++ b/test/snapshots/missing-argument-elm-format-path.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --elm-format-path flag needs more information.
 

--- a/test/snapshots/missing-argument-elm-format-path.txt
+++ b/test/snapshots/missing-argument-elm-format-path.txt
@@ -2,7 +2,8 @@
 
 The --elm-format-path flag needs more information.
 
-It needs the path to the elm-format binary like:
+Here is the documentation for this flag:
 
     --elm-format-path <path-to-elm-format>
+        Specify the path to elm-format.
 

--- a/test/snapshots/missing-argument-elm-format-path.txt
+++ b/test/snapshots/missing-argument-elm-format-path.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --elm-format-path flag needs more information.
+
+It needs the path to the elm-format binary like:
+
+    --elm-format-path <path-to-elm-format>
+

--- a/test/snapshots/missing-argument-elmjson.txt
+++ b/test/snapshots/missing-argument-elmjson.txt
@@ -2,7 +2,9 @@
 
 The --elmjson flag needs more information.
 
-It needs the path to the project's elm.json like:
+Here is the documentation for this flag:
 
     --elmjson <path-to-elm.json>
+        Specify the path to the elm.json file of the project. By default,
+        the one in the current directory or its parent directories will be used.
 

--- a/test/snapshots/missing-argument-elmjson.txt
+++ b/test/snapshots/missing-argument-elmjson.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --elmjson flag needs more information.
+
+It needs the path to the project's elm.json like:
+
+    --elmjson <path-to-elm.json>
+

--- a/test/snapshots/missing-argument-elmjson.txt
+++ b/test/snapshots/missing-argument-elmjson.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --elmjson flag needs more information.
 

--- a/test/snapshots/missing-argument-init-compiler.txt
+++ b/test/snapshots/missing-argument-init-compiler.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --compiler flag needs more information.
 

--- a/test/snapshots/missing-argument-init-compiler.txt
+++ b/test/snapshots/missing-argument-init-compiler.txt
@@ -2,7 +2,8 @@
 
 The --compiler flag needs more information.
 
-It needs the path to the Elm binary like:
+Here is the documentation for this flag:
 
     --compiler <path-to-elm>
+        Specify the path to the elm compiler.
 

--- a/test/snapshots/missing-argument-init-compiler.txt
+++ b/test/snapshots/missing-argument-init-compiler.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --compiler flag needs more information.
+
+It needs the path to the Elm binary like:
+
+    --compiler <path-to-elm>
+

--- a/test/snapshots/missing-argument-init-compiler.txt
+++ b/test/snapshots/missing-argument-init-compiler.txt
@@ -6,4 +6,7 @@ Here is the documentation for this flag:
 
     --compiler <path-to-elm>
         Specify the path to the elm compiler.
+        The elm compiler is used to know the version of the compiler to write
+        down in the review/elm.json file’s `elm-version` field. Use this if you
+        have multiple versions of the elm compiler on your device.
 

--- a/test/snapshots/missing-argument-init-config.txt
+++ b/test/snapshots/missing-argument-init-config.txt
@@ -2,7 +2,9 @@
 
 The --config flag needs more information.
 
-It needs the path to the review configuration directory like:
+Here is the documentation for this flag:
 
     --config <path-to-review-directory>
+        Use the review configuration in the specified directory instead of the
+        one found in the current directory or one of its parents.
 

--- a/test/snapshots/missing-argument-init-config.txt
+++ b/test/snapshots/missing-argument-init-config.txt
@@ -5,6 +5,6 @@ The --config flag needs more information.
 Here is the documentation for this flag:
 
     --config <path-to-review-directory>
-        Use the review configuration in the specified directory instead of the
-        one found in the current directory or one of its parents.
+        Create the configuration files in the specified directory instead of in
+        the review/ directory.
 

--- a/test/snapshots/missing-argument-init-config.txt
+++ b/test/snapshots/missing-argument-init-config.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --config flag needs more information.
 

--- a/test/snapshots/missing-argument-init-config.txt
+++ b/test/snapshots/missing-argument-init-config.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --config flag needs more information.
+
+It needs the path to the review configuration directory like:
+
+    --config <path-to-review-directory>
+

--- a/test/snapshots/missing-argument-init-template.txt
+++ b/test/snapshots/missing-argument-init-template.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --template flag needs more information.
+
+It needs the GitHub repository like:
+
+    --template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]
+

--- a/test/snapshots/missing-argument-init-template.txt
+++ b/test/snapshots/missing-argument-init-template.txt
@@ -2,7 +2,16 @@
 
 The --template flag needs more information.
 
-It needs the GitHub repository like:
+Here is the documentation for this flag:
 
     --template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]
+        Use the review configuration from a GitHub repository. You can use this
+        to try out elm-review, a configuration or a single rule.
+        This flag requires Internet access, even after the first run.
+        Examples:
+          - elm-review --template author/elm-review-configuration
+          - elm-review --template jfmengels/elm-review-unused/example#master
+
+        I recommend to only use this temporarily, and run elm-review init with
+        this same flag to copy the configuration to your project.
 

--- a/test/snapshots/missing-argument-init-template.txt
+++ b/test/snapshots/missing-argument-init-template.txt
@@ -5,13 +5,9 @@ The --template flag needs more information.
 Here is the documentation for this flag:
 
     --template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]
-        Use the review configuration from a GitHub repository. You can use this
-        to try out elm-review, a configuration or a single rule.
-        This flag requires Internet access, even after the first run.
+        Copy the review configuration from a GitHub repository, at the root or
+        in a folder.
         Examples:
-          - elm-review --template author/elm-review-configuration
-          - elm-review --template jfmengels/elm-review-unused/example#master
-
-        I recommend to only use this temporarily, and run elm-review init with
-        this same flag to copy the configuration to your project.
+          - elm-review init --template author/elm-review-configuration
+          - elm-review init --template jfmengels/elm-review-unused/example#master
 

--- a/test/snapshots/missing-argument-init-template.txt
+++ b/test/snapshots/missing-argument-init-template.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --template flag needs more information.
 

--- a/test/snapshots/missing-argument-new-package-compiler.txt
+++ b/test/snapshots/missing-argument-new-package-compiler.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --compiler flag needs more information.
 

--- a/test/snapshots/missing-argument-new-package-compiler.txt
+++ b/test/snapshots/missing-argument-new-package-compiler.txt
@@ -2,7 +2,8 @@
 
 The --compiler flag needs more information.
 
-It needs the path to the Elm binary like:
+Here is the documentation for this flag:
 
     --compiler <path-to-elm>
+        Specify the path to the elm compiler.
 

--- a/test/snapshots/missing-argument-new-package-compiler.txt
+++ b/test/snapshots/missing-argument-new-package-compiler.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --compiler flag needs more information.
+
+It needs the path to the Elm binary like:
+
+    --compiler <path-to-elm>
+

--- a/test/snapshots/missing-argument-new-package-compiler.txt
+++ b/test/snapshots/missing-argument-new-package-compiler.txt
@@ -6,4 +6,7 @@ Here is the documentation for this flag:
 
     --compiler <path-to-elm>
         Specify the path to the elm compiler.
+        The elm compiler is used to know the version of the compiler to write
+        down in the review/elm.json file’s `elm-version` field. Use this if you
+        have multiple versions of the elm compiler on your device.
 

--- a/test/snapshots/missing-argument-report.txt
+++ b/test/snapshots/missing-argument-report.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --report flag needs more information.
+
+It needs the report format like:
+
+    --report=<json or ndjson>
+

--- a/test/snapshots/missing-argument-report.txt
+++ b/test/snapshots/missing-argument-report.txt
@@ -2,7 +2,10 @@
 
 The --report flag needs more information.
 
-It needs the report format like:
+Here is the documentation for this flag:
 
     --report=<json or ndjson>
+        Error reports will be in JSON format. json prints a single JSON object
+        while ndjson will print one JSON object per error each on a new line.
+        The formats are described in this document: https://bit.ly/31F6jzz
 

--- a/test/snapshots/missing-argument-report.txt
+++ b/test/snapshots/missing-argument-report.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --report flag needs more information.
 

--- a/test/snapshots/missing-argument-rules.txt
+++ b/test/snapshots/missing-argument-rules.txt
@@ -2,7 +2,9 @@
 
 The --rules flag needs more information.
 
-It needs the list of rules to enable separated by commas like:
+Here is the documentation for this flag:
 
     --rules <rule1,rule2,...>
+        Run with a subsection of the rules in the configuration. Specify them
+        by their name, and separate them by commas.
 

--- a/test/snapshots/missing-argument-rules.txt
+++ b/test/snapshots/missing-argument-rules.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --rules flag needs more information.
+
+It needs the list of rules to enable separated by commas like:
+
+    --rules <rule1,rule2,...>
+

--- a/test/snapshots/missing-argument-rules.txt
+++ b/test/snapshots/missing-argument-rules.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --rules flag needs more information.
 

--- a/test/snapshots/missing-argument-template.txt
+++ b/test/snapshots/missing-argument-template.txt
@@ -1,0 +1,8 @@
+-- INVALID ARGUMENT ------------------------------------------------------------
+
+The --template flag needs more information.
+
+It needs the GitHub repository like:
+
+    --template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]
+

--- a/test/snapshots/missing-argument-template.txt
+++ b/test/snapshots/missing-argument-template.txt
@@ -2,7 +2,16 @@
 
 The --template flag needs more information.
 
-It needs the GitHub repository like:
+Here is the documentation for this flag:
 
     --template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]
+        Use the review configuration from a GitHub repository. You can use this
+        to try out elm-review, a configuration or a single rule.
+        This flag requires Internet access, even after the first run.
+        Examples:
+          - elm-review --template author/elm-review-configuration
+          - elm-review --template jfmengels/elm-review-unused/example#master
+
+        I recommend to only use this temporarily, and run elm-review init with
+        this same flag to copy the configuration to your project.
 

--- a/test/snapshots/missing-argument-template.txt
+++ b/test/snapshots/missing-argument-template.txt
@@ -1,4 +1,4 @@
--- INVALID ARGUMENT ------------------------------------------------------------
+-- MISSING FLAG ARGUMENT -------------------------------------------------------
 
 The --template flag needs more information.
 

--- a/test/snapshots/report-unknown-argument.txt
+++ b/test/snapshots/report-unknown-argument.txt
@@ -1,0 +1,11 @@
+-- INVALID FLAG ARGUMENT -------------------------------------------------------
+
+The value unknown passed to --report is not a valid one.
+
+Here is the documentation for this flag:
+
+    --report=<json or ndjson>
+        Error reports will be in JSON format. json prints a single JSON object
+        while ndjson will print one JSON object per error each on a new line.
+        The formats are described in this document: https://bit.ly/31F6jzz
+

--- a/test/snapshots/template-bad-argument.txt
+++ b/test/snapshots/template-bad-argument.txt
@@ -1,0 +1,17 @@
+-- INVALID FLAG ARGUMENT -------------------------------------------------------
+
+The value not-github-repo passed to --template is not a valid one.
+
+Here is the documentation for this flag:
+
+    --template <author>/<repo>[/path-to-the-config-folder][#branch-or-commit]
+        Use the review configuration from a GitHub repository. You can use this
+        to try out elm-review, a configuration or a single rule.
+        This flag requires Internet access, even after the first run.
+        Examples:
+          - elm-review --template author/elm-review-configuration
+          - elm-review --template jfmengels/elm-review-unused/example#master
+
+        I recommend to only use this temporarily, and run elm-review init with
+        this same flag to copy the configuration to your project.
+

--- a/test/snapshots/unknown-flag.txt
+++ b/test/snapshots/unknown-flag.txt
@@ -1,0 +1,11 @@
+-- UNKNOWN FLAG ----------------------------------------------------------------
+
+I did not recognize this flag:
+
+    watc
+
+Maybe you want one of these instead?
+
+    --watch
+    --help
+

--- a/test/snapshots/unknown-shorthand-flag.txt
+++ b/test/snapshots/unknown-shorthand-flag.txt
@@ -1,0 +1,6 @@
+-- UNKNOWN FLAG ----------------------------------------------------------------
+
+I did not recognize this shorthand flag: -u
+
+I only know these: -h, -v
+


### PR DESCRIPTION
- Fixes #26: Report when a non-binary flag is missing a value

![Screenshot from 2021-03-05 22-32-01](https://user-images.githubusercontent.com/3869412/110177377-296ede00-7e05-11eb-869b-a6651e1eaa9a.png)

- Report about invalid values for some non-binary flags (where a value could cause a crash if unchecked)

![Screenshot from 2021-03-05 22-55-38](https://user-images.githubusercontent.com/3869412/110177889-efeaa280-7e05-11eb-9c2b-bed7b787ec8d.png)

- Report about unknown flags

![Screenshot from 2021-03-05 22-31-28](https://user-images.githubusercontent.com/3869412/110177376-296ede00-7e05-11eb-8d3d-b9afd93cfe69.png)

- Report about unknown shorthand flags

![Screenshot from 2021-03-05 22-54-51](https://user-images.githubusercontent.com/3869412/110177813-d21d3d80-7e05-11eb-8bcc-000254a43a42.png)