### PR TITLE
new-package: Add bump script

### DIFF
--- a/lib/new-package.js
+++ b/lib/new-package.js
@@ -348,6 +348,10 @@ function packageJson(options, packageName) {
       'test:review': 'elm-review',
       'test:package': 'node elm-review-package-tests/check-previews-compile.js',
       'preview-docs': 'elm-doc-preview',
+      'elm-bump':
+        "npm-run-all --print-name --silent --sequential test bump-version 'test:review -- --fix-all-without-prompt' update-examples",
+      'bump-version': '(yes | elm bump)',
+      'update-examples': 'node maintenance/update-examples-from-preview.js',
       postinstall: 'elm-tooling install'
     },
     dependencies: {

--- a/lib/new-package.js
+++ b/lib/new-package.js
@@ -358,6 +358,7 @@ function packageJson(options, packageName) {
       'elm-doc-preview': '^5.0.3',
       'elm-review': `^${options.packageJsonVersion}`,
       'elm-test': '^0.19.1-revision6',
+      'elm-tooling': '^1.3.0',
       'fs-extra': '9.0.0',
       glob: '7.1.6',
       'npm-run-all': '^4.1.5'

--- a/new-package/maintenance/MAINTENANCE.md
+++ b/new-package/maintenance/MAINTENANCE.md
@@ -113,23 +113,12 @@ Contrary to the initial release, the CI will automatically try to publish a new 
 Here is a script that you can run to publish your package, which will help you avoid errors showing up at the CI stage.
 
 ```bash
-# Bump the version of the package
-elm bump
-
-# Run elm-review, which will for instance auto-fix like documentation links
-elm-review --fix-all
-
-# Run the tests, fix them if necessary
-npm test
-
-# Update the example configurations to reflect what was previously in the
-# preview configurations
-node maintenance/update-examples-from-preview.js
+npm run elm-bump
 
 # Commit it all
 git add --all
-git commit
+git commit # You'll need to specify a message
 git push origin HEAD
 
-# Now wait for CI to finish
+# Now wait for CI to finish and check that it succeeded
 ```

--- a/test/snapshots/elm-review-something-for-new-rule/maintenance/MAINTENANCE.md
+++ b/test/snapshots/elm-review-something-for-new-rule/maintenance/MAINTENANCE.md
@@ -113,23 +113,12 @@ Contrary to the initial release, the CI will automatically try to publish a new 
 Here is a script that you can run to publish your package, which will help you avoid errors showing up at the CI stage.
 
 ```bash
-# Bump the version of the package
-elm bump
-
-# Run elm-review, which will for instance auto-fix like documentation links
-elm-review --fix-all
-
-# Run the tests, fix them if necessary
-npm test
-
-# Update the example configurations to reflect what was previously in the
-# preview configurations
-node maintenance/update-examples-from-preview.js
+npm run elm-bump
 
 # Commit it all
 git add --all
-git commit
+git commit # You'll need to specify a message
 git push origin HEAD
 
-# Now wait for CI to finish
+# Now wait for CI to finish and check that it succeeded
 ```

--- a/test/snapshots/elm-review-something-for-new-rule/package.json
+++ b/test/snapshots/elm-review-something-for-new-rule/package.json
@@ -17,6 +17,7 @@
     "elm-doc-preview": "^5.0.3",
     "elm-review": "^2.4.6",
     "elm-test": "^0.19.1-revision6",
+    "elm-tooling": "^1.3.0",
     "fs-extra": "9.0.0",
     "glob": "7.1.6",
     "npm-run-all": "^4.1.5"

--- a/test/snapshots/elm-review-something-for-new-rule/package.json
+++ b/test/snapshots/elm-review-something-for-new-rule/package.json
@@ -8,6 +8,9 @@
     "test:review": "elm-review",
     "test:package": "node elm-review-package-tests/check-previews-compile.js",
     "preview-docs": "elm-doc-preview",
+    "elm-bump": "npm-run-all --print-name --silent --sequential test bump-version 'test:review -- --fix-all-without-prompt' update-examples",
+    "bump-version": "(yes | elm bump)",
+    "update-examples": "node maintenance/update-examples-from-preview.js",
     "postinstall": "elm-tooling install"
   },
   "dependencies": {

--- a/test/snapshots/elm-review-something/maintenance/MAINTENANCE.md
+++ b/test/snapshots/elm-review-something/maintenance/MAINTENANCE.md
@@ -113,23 +113,12 @@ Contrary to the initial release, the CI will automatically try to publish a new 
 Here is a script that you can run to publish your package, which will help you avoid errors showing up at the CI stage.
 
 ```bash
-# Bump the version of the package
-elm bump
-
-# Run elm-review, which will for instance auto-fix like documentation links
-elm-review --fix-all
-
-# Run the tests, fix them if necessary
-npm test
-
-# Update the example configurations to reflect what was previously in the
-# preview configurations
-node maintenance/update-examples-from-preview.js
+npm run elm-bump
 
 # Commit it all
 git add --all
-git commit
+git commit # You'll need to specify a message
 git push origin HEAD
 
-# Now wait for CI to finish
+# Now wait for CI to finish and check that it succeeded
 ```

--- a/test/snapshots/elm-review-something/package.json
+++ b/test/snapshots/elm-review-something/package.json
@@ -17,6 +17,7 @@
     "elm-doc-preview": "^5.0.3",
     "elm-review": "^2.4.6",
     "elm-test": "^0.19.1-revision6",
+    "elm-tooling": "^1.3.0",
     "fs-extra": "9.0.0",
     "glob": "7.1.6",
     "npm-run-all": "^4.1.5"

--- a/test/snapshots/elm-review-something/package.json
+++ b/test/snapshots/elm-review-something/package.json
@@ -8,6 +8,9 @@
     "test:review": "elm-review",
     "test:package": "node elm-review-package-tests/check-previews-compile.js",
     "preview-docs": "elm-doc-preview",
+    "elm-bump": "npm-run-all --print-name --silent --sequential test bump-version 'test:review -- --fix-all-without-prompt' update-examples",
+    "bump-version": "(yes | elm bump)",
+    "update-examples": "node maintenance/update-examples-from-preview.js",
     "postinstall": "elm-tooling install"
   },
   "dependencies": {


### PR DESCRIPTION
Adds an easy script to bump the version of a package created with `new-package`.

I often do these steps but forget run `node maintenance/update-examples-from-preview.js'` which then fails at CI. Having this npm script should help out myself and others.