### PR TITLE
Fix misunderstanding location of elm parser js file

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -181,7 +181,8 @@ path.relative(process.cwd(), 'elm.json')
     elmModulePath: (appHash /* : string */) =>
       path.join(elmStuffFolder(), 'review-applications', `${appHash}.js`),
     elmParserPath: (elmSyntaxVersion /* : string */) =>
-      path.join(
+      path.resolve(
+        process.cwd(),
         elmStuffFolder(),
         'elm-parser',
         `elm-syntax-v${elmSyntaxVersion}${args.debug ? '-debug' : ''}.js`


### PR DESCRIPTION
Fixes #40 

@Janiczek could you check that this works for you? :slightly_smiling_face: 

- Checkout this repo
- Instead of running `elm-review`, run `<this folder>/bin/elm-review`, + the arguments you used to reproduce the error.