### PR TITLE
Wrap elm-format filepath argument so the paths can include whitespace

### DIFF
--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -106,7 +106,7 @@ function formatFileContent(options, file, filePath) {
   if (options.elmFormatPath) {
     const spawnedUsingPathFromArgs = spawn.sync(
       options.elmFormatPath,
-      ['--elm-version=0.19', '--stdin', '--output', filePath],
+      ['--elm-version=0.19', '--stdin', '--output', `"${filePath}"`],
       {
         shell: true,
         input: file.source
@@ -135,7 +135,7 @@ function formatFileContent(options, file, filePath) {
         '--elm-version=0.19',
         '--stdin',
         '--output',
-        filePath
+        `"${filePath}"`
       ],
       {
         shell: true,
@@ -162,7 +162,7 @@ A few options:
 
       const spawnedUsingGlobal = spawn.sync(
         'elm-format',
-        ['--yes', '--elm-version=0.19', '--stdin', '--output', filePath],
+        ['--yes', '--elm-version=0.19', '--stdin', '--output', `"${filePath}"`],
         {
           shell: true,
           input: file.source


### PR DESCRIPTION
Hello (: I store some of my projects in a path that includes a whitespace (🏄‍♀️). When running `elm-review --fix-all`, it passes each file to `elm-format` but doesn't quote them, which causes the command to fail with a "Can't find file" error. This change wraps the file path argument in quotes. I am also happy to add tests, but wanted to see what you thought first.
Cheers