### PR TITLE
Do what we can to avoid command injection

### DIFF
--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -106,9 +106,8 @@ function formatFileContent(options, file, filePath) {
   if (options.elmFormatPath) {
     const spawnedUsingPathFromArgs = spawn.sync(
       options.elmFormatPath,
-      ['--elm-version=0.19', '--stdin', '--output', `"${filePath}"`],
+      ['--elm-version=0.19', '--stdin', '--output', filePath],
       {
-        shell: true,
         input: file.source
       }
     );
@@ -135,10 +134,9 @@ function formatFileContent(options, file, filePath) {
         '--elm-version=0.19',
         '--stdin',
         '--output',
-        `"${filePath}"`
+        filePath
       ],
       {
-        shell: true,
         input: file.source
       }
     );
@@ -162,9 +160,8 @@ A few options:
 
       const spawnedUsingGlobal = spawn.sync(
         'elm-format',
-        ['--yes', '--elm-version=0.19', '--stdin', '--output', `"${filePath}"`],
+        ['--yes', '--elm-version=0.19', '--stdin', '--output', filePath],
         {
-          shell: true,
           input: file.source
         }
       );


### PR DESCRIPTION
If you have a source-directory named `$(touch pwned)` (like one typically does 😅 ), running `elm-review --fix` results in command injection – a file called `pwned` is created in this case.

Repro repo: https://github.com/lydell/elm-review-command-injection

This is because some `spawn` calls use `shell: true`. This means “I want my arguments to be interpreted as shell script”, but that’s not what we want in elm-review’s case – we want all arguments to be passed as-is to the program we’re spawning.

(Note: One reason to use `shell: true` with Node.js’ built-in `spawn` function is to be able to spawn more stuff on Windows, but we’re already using cross-spawn so that’s not something we need to think about: https://github.com/moxystudio/node-cross-spawn#using-optionsshell-as-an-alternative-to-cross-spawn)

As far as I can tell, `shell: true` has been there since the code was written. https://github.com/jfmengels/node-elm-review/pull/43 noticed something was up with the arguments handling, but solved it with a non-sufficient escape technique.

I’ve tested this on my repro repo. That example also has a space in a folder name and things still work, so https://github.com/jfmengels/node-elm-review/pull/43 should still be fixed.
