### PR TITLE
Improve error message when entering an invalid rule name

### DIFF
--- a/lib/new-rule.js
+++ b/lib/new-rule.js
@@ -42,7 +42,7 @@ function readElmJson(options) {
   }
 }
 
-const ruleNameRegex = /^[A-Z][\d\w_]*(\.[A-Z][\d\w_]*)*$/;
+const ruleNameRegex = /^[A-Z]\w*(\.[A-Z]\w*)*$/;
 
 function validateRuleName(ruleName) {
   if (!ruleNameRegex.test(ruleName)) {

--- a/lib/new-rule.js
+++ b/lib/new-rule.js
@@ -48,7 +48,7 @@ function validateRuleName(ruleName) {
   if (!ruleNameRegex.test(ruleName)) {
     throw new ErrorMessage.CustomError(
       'INVALID RULE NAME',
-      'The rule name needs to be a valid module name.'
+      'The rule name needs to be a valid Elm module name that only contains characters A-Z, digits and `_`.'
     );
   }
 }
@@ -74,7 +74,9 @@ async function askForRuleName() {
   }
 
   if (!ruleNameRegex.test(ruleName)) {
-    console.log('The rule name needs to a valid module name.');
+    console.log(
+      'The rule name needs to be a valid Elm module name that only contains characters A-Z, digits and `_`.'
+    );
     return askForRuleName();
   }
 


### PR DESCRIPTION
Fixes #47 

Instead of allowing unicode characters, I improved the error message saying what isn't allowed. We noticed that some tools, like Git, don't support "exotic" characters too well (in things like `git status -s`, and allowing these characters would make it harder for other people to use a published role.

People can still workaround this by renaming the module if they really want to.