### PR TITLE
Error in "successive releases" example script?

### DIFF
--- a/new-package/maintenance/MAINTENANCE.md
+++ b/new-package/maintenance/MAINTENANCE.md
@@ -117,7 +117,7 @@ Contrary to the initial release, the CI will automatically try to publish a new 
 Here is a script that you can run to publish your package, which will help you avoid errors showing up at the CI stage.
 
 ```bash
-npm run elm-bump
+npx elm bump
 
 # Commit it all
 git add --all


### PR DESCRIPTION
I had trouble running the `npm run elm bump` line in the script for successive releases. Is there a missing `elm-bump` package script? Or perhaps some `elm-bump` tool (à la `elm-json`) that I'm not aware of?

Either way, I found that `npx elm bump` and `yarn elm bump` both do the trick here, so I figured I'd at least propose it.

P.S. Thanks for `elm-review. This package (and tools you bundle to maintain rules) have been :exploding_head: my mind!