### PR TITLE
Check whether a source directory is a file by checking it with the file system

### DIFF
--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -251,8 +251,12 @@ async function findForCliArguments(directory, path_) {
     return findFromFolder(directory, path_);
   } catch (error) {
     if (error.code === 'ENOENT') {
-      // File was not found
-      return undefined;
+      // File/folder was not found. Return an empty array, which will give a nice
+      // error report in the parent function
+      return {
+        files: [],
+        directory
+      };
     }
 
     throw error;

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -212,7 +212,8 @@ async function findFiles(directory) {
   const path_ = directory.replace(/.:/, '').replace(/\\/g, '/');
   const ignore = ['**/elm-stuff/**'];
 
-  if (path_.endsWith('.elm')) {
+  const stat = await fsStat(directory);
+  if (stat.isFile()) {
     // For finding files when `directory` is a direct Elm file, like "src/File.elm"
     return {
       files: await globAsync(path_, {

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -39,7 +39,7 @@ async function getProjectFiles(options, elmSyntaxVersion) {
 
   const filesInDirectories = await Promise.all(
     sourceDirectories.map((dir) => findFiles(isFromCliArguments, dir))
-  ).then((array) => array.filter(Boolean));
+  );
 
   const emptyDirectories = filesInDirectories.filter(
     ({files}) => files.length === 0

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -32,11 +32,14 @@ async function getProjectFiles(options, elmSyntaxVersion) {
   AppState.readmeChanged(readme);
 
   const elmJson = JSON.parse(elmJsonRaw);
-  const sourcesDirectories = getSourceDirectories(options, elmJson);
+  const {isFromCliArguments, sourceDirectories} = getSourceDirectories(
+    options,
+    elmJson
+  );
 
   const filesInDirectories = await Promise.all(
-    sourcesDirectories.map(findFiles)
-  ).then(array => array.filter(Boolean));
+    sourceDirectories.map((dir) => findFiles(isFromCliArguments, dir))
+  ).then((array) => array.filter(Boolean));
 
   const emptyDirectories = filesInDirectories.filter(
     ({files}) => files.length === 0
@@ -89,7 +92,7 @@ misconfigured the CLI’s arguments.`
     },
     readme,
     elmFiles,
-    sourcesDirectories
+    sourceDirectories
   };
 }
 
@@ -184,13 +187,23 @@ async function getReadme(options, directoryContainingElmJson) {
 }
 
 function getSourceDirectories(options, elmJson) {
-  const projectToReview = options.projectToReview();
-
   if (options.directoriesToAnalyze.length !== 0) {
-    return options.directoriesToAnalyze.map((directory) =>
-      path.resolve(process.cwd(), directory)
-    );
+    return {
+      isFromCliArguments: true,
+      sourceDirectories: options.directoriesToAnalyze.map((directory) =>
+        path.resolve(process.cwd(), directory)
+      )
+    };
   }
+
+  return {
+    isFromCliArguments: false,
+    sourceDirectories: standardSourceDirectories(options, elmJson)
+  };
+}
+
+function standardSourceDirectories(options, elmJson) {
+  const projectToReview = options.projectToReview();
 
   if (elmJson.type === 'package') {
     return [
@@ -206,11 +219,20 @@ function getSourceDirectories(options, elmJson) {
     .concat(path.join(projectToReview, 'tests'));
 }
 
-async function findFiles(directory) {
+function findFiles(isFromCliArguments, directory) {
   // Replacing parts to make the globbing work on Windows
   const path_ = directory.replace(/.:/, '').replace(/\\/g, '/');
-  const ignore = ['**/elm-stuff/**'];
 
+  if (isFromCliArguments) {
+    return findForCliArguments(directory, path_);
+  }
+
+  return findFromFolder(directory, path_);
+}
+
+const globIgnore = ['**/elm-stuff/**'];
+
+async function findForCliArguments(directory, path_) {
   try {
     const stat = await fsStat(directory);
     if (stat.isFile()) {
@@ -218,22 +240,15 @@ async function findFiles(directory) {
       return {
         files: await globAsync(path_, {
           nocase: true,
-          ignore,
+          ignore: globIgnore,
           nodir: true
         }),
         directory
       };
     }
 
-    // For finding files when `directory` is a directory, like "src/"
-    return {
-      files: await globAsync(`${path_}/**/*.elm`, {
-        nocase: true,
-        ignore,
-        nodir: false
-      }),
-      directory
-    };
+    // For finding files when `directory` is a directory, like "src/" or "tests"
+    return findFromFolder(directory, path_);
   } catch (error) {
     if (error.code === 'ENOENT') {
       // File was not found
@@ -242,6 +257,17 @@ async function findFiles(directory) {
 
     throw error;
   }
+}
+
+async function findFromFolder(directory, path_) {
+  return {
+    files: await globAsync(`${path_}/**/*.elm`, {
+      nocase: true,
+      ignore: globIgnore,
+      nodir: false
+    }),
+    directory
+  };
 }
 
 function fsReadLatestUpdatedTime(filePath) {

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -36,7 +36,7 @@ async function getProjectFiles(options, elmSyntaxVersion) {
 
   const filesInDirectories = await Promise.all(
     sourcesDirectories.map(findFiles)
-  );
+  ).then(array => array.filter(Boolean));
 
   const emptyDirectories = filesInDirectories.filter(
     ({files}) => files.length === 0
@@ -212,28 +212,37 @@ async function findFiles(directory) {
   const path_ = directory.replace(/.:/, '').replace(/\\/g, '/');
   const ignore = ['**/elm-stuff/**'];
 
-  const stat = await fsStat(directory);
-  if (stat.isFile()) {
-    // For finding files when `directory` is a direct Elm file, like "src/File.elm"
+  try {
+    const stat = await fsStat(directory);
+    if (stat.isFile()) {
+      // For finding files when `directory` is a direct Elm file, like "src/File.elm"
+      return {
+        files: await globAsync(path_, {
+          nocase: true,
+          ignore,
+          nodir: true
+        }),
+        directory
+      };
+    }
+
+    // For finding files when `directory` is a directory, like "src/"
     return {
-      files: await globAsync(path_, {
+      files: await globAsync(`${path_}/**/*.elm`, {
         nocase: true,
         ignore,
-        nodir: true
+        nodir: false
       }),
       directory
     };
-  }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      // File was not found
+      return undefined;
+    }
 
-  // For finding files when `directory` is a directory, like "src/"
-  return {
-    files: await globAsync(`${path_}/**/*.elm`, {
-      nocase: true,
-      ignore,
-      nodir: false
-    }),
-    directory
-  };
+    throw error;
+  }
 }
 
 function fsReadLatestUpdatedTime(filePath) {

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -185,10 +185,9 @@ async function getReadme(options, directoryContainingElmJson) {
 
 function getSourceDirectories(options, elmJson) {
   const projectToReview = options.projectToReview();
-  const {directoriesToAnalyze} = options;
 
-  if (directoriesToAnalyze.length !== 0) {
-    return directoriesToAnalyze.map((directory) =>
+  if (options.directoriesToAnalyze.length !== 0) {
+    return options.directoriesToAnalyze.map((directory) =>
       path.resolve(process.cwd(), directory)
     );
   }

--- a/test/project-with-dir-ending-in-elm/elm.json
+++ b/test/project-with-dir-ending-in-elm/elm.json
@@ -1,0 +1,24 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src.elm"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/test/project-with-dir-ending-in-elm/src.elm/Main.elm
+++ b/test/project-with-dir-ending-in-elm/src.elm/Main.elm
@@ -1,0 +1,5 @@
+module Main exposing (main)
+
+import Html
+
+main = Html.text "Hello"

--- a/test/run.sh
+++ b/test/run.sh
@@ -148,6 +148,7 @@ PACKAGE_PATH=$(npm pack -s ../ | tail -n 1)
 echo "Package path is $PACKAGE_PATH"
 npm install -g $PACKAGE_PATH
 
+
 # Version
 
 $createTest "$CMD" \
@@ -374,6 +375,23 @@ createTestSuiteWithDifferentReportFormats "$CMD" \
     "Using an configuration which fails due to debug remnants" \
     "--config ../config-error-debug" \
     "config-error-debug"
+
+$createTest "$CMD" \
+    "Running on project with unknown file" \
+    "--config ../config-that-triggers-no-errors unknown-target" \
+    "run-with-unknown-target.txt"
+
+cd "$CWD/project-with-dir-ending-in-elm"
+
+$createTest "$CMD" \
+    "Running on project with a directory ending in .elm" \
+    "--config ../config-that-triggers-no-errors" \
+    "src.elm-project-without-arg.txt"
+
+$createTest "$CMD" \
+    "Running on project with a directory ending in .elm" \
+    "--config ../config-that-triggers-no-errors src.elm" \
+    "src.elm-project-with-arg.txt"
 
 # FIXES
 

--- a/test/snapshots/run-with-unknown-target.txt
+++ b/test/snapshots/run-with-unknown-target.txt
@@ -1,0 +1,9 @@
+-- NO FILES FOUND --------------------------------------------------------------
+
+I was expecting to find Elm files in all the paths that you passed, but I could
+not find any in the following directories:
+- <local-path>/test/project-with-errors/unknown-target
+
+When I can’t find files in some of the directories, I’m assuming that you
+misconfigured the CLI’s arguments.
+

--- a/test/snapshots/src.elm-project-with-arg.txt
+++ b/test/snapshots/src.elm-project-with-arg.txt
@@ -1,0 +1,1 @@
+I found no errors!

--- a/test/snapshots/src.elm-project-without-arg.txt
+++ b/test/snapshots/src.elm-project-without-arg.txt
@@ -1,0 +1,1 @@
+I found no errors!


### PR DESCRIPTION
Fixes #52

@dbandstra I added some tests and noticed your solution didn't work out for several reasons (though I did what you suggested, so it was useful, thanks :) )
- The `fsStat` was indeed running even without passing arguments
- Therefore when you don't add arguments, `tests/` gets added automatically and if you don't have any, there is a crash about it not existing.


If you could test this out that'd be great :blush: 