### PR TITLE
Update and fix elm-tooling usage

### DIFF
--- a/lib/new-package.js
+++ b/lib/new-package.js
@@ -3,7 +3,7 @@ const childProcess = require('child_process');
 const chalk = require('chalk');
 const fs = require('fs-extra');
 const prompts = require('prompts');
-const elmToolingCli = require('elm-tooling').default;
+const elmToolingCli = require('elm-tooling');
 const Init = require('./init');
 const Spinner = require('./spinner');
 const NewRule = require('./new-rule');
@@ -358,7 +358,7 @@ function packageJson(options, packageName) {
       'elm-doc-preview': '^5.0.3',
       'elm-review': `^${options.packageJsonVersion}`,
       'elm-test': '^0.19.1-revision6',
-      'elm-tooling': '^1.3.0',
+      'elm-tooling': '^1.4.1',
       'fs-extra': '9.0.0',
       glob: '7.1.6',
       'npm-run-all': '^4.1.5'

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "chalk": "^4.0.0",
     "chokidar": "^3.4.0",
     "cross-spawn": "^7.0.3",
-    "elm-tooling": "^1.4.0",
+    "elm-tooling": "^1.4.1",
     "fast-levenshtein": "^3.0.0",
     "find-up": "^4.1.0",
     "folder-hash": "^3.3.0",

--- a/test/snapshots/elm-review-something-for-new-rule/package.json
+++ b/test/snapshots/elm-review-something-for-new-rule/package.json
@@ -17,7 +17,7 @@
     "elm-doc-preview": "^5.0.3",
     "elm-review": "^2.5.5",
     "elm-test": "^0.19.1-revision6",
-    "elm-tooling": "^1.3.0",
+    "elm-tooling": "^1.4.1",
     "fs-extra": "9.0.0",
     "glob": "7.1.6",
     "npm-run-all": "^4.1.5"

--- a/test/snapshots/elm-review-something/package.json
+++ b/test/snapshots/elm-review-something/package.json
@@ -17,7 +17,7 @@
     "elm-doc-preview": "^5.0.3",
     "elm-review": "^2.5.5",
     "elm-test": "^0.19.1-revision6",
-    "elm-tooling": "^1.3.0",
+    "elm-tooling": "^1.4.1",
     "fs-extra": "9.0.0",
     "glob": "7.1.6",
     "npm-run-all": "^4.1.5"


### PR DESCRIPTION
elm-tooling 1.4.0 accidentally shipped with faulty exports, which was fixed in 1.4.1: https://github.com/elm-tooling/elm-tooling-cli/blob/b292a8169019e5ef5b348a0d006807ca8472c5d8/CHANGELOG.md#version-141-2021-08-22

This PR makes sure 1.4.1 or newer is used, and reverts https://github.com/jfmengels/node-elm-review/commit/5f81e8ebdd05894fc8ed349d93bce9b83e96dd6e (which accounted for the faulty export).