### PR TITLE
new-package: Add `elm-format` checks for preview files

### DIFF
--- a/lib/new-package.js
+++ b/lib/new-package.js
@@ -343,7 +343,7 @@ function packageJson(options, packageName) {
       test:
         'npm-run-all --print-name --silent --sequential test:make test:format test:run test:review test:package',
       'test:make': 'elm make --docs=docs.json',
-      'test:format': 'elm-format src/ tests/ --validate',
+      'test:format': 'elm-format src/ preview*/**.elm tests/ --validate',
       'test:run': 'elm-test',
       'test:review': 'elm-review',
       'test:package': 'node elm-review-package-tests/check-previews-compile.js',

--- a/lib/new-package.js
+++ b/lib/new-package.js
@@ -343,7 +343,7 @@ function packageJson(options, packageName) {
       test:
         'npm-run-all --print-name --silent --sequential test:make test:format test:run test:review test:package',
       'test:make': 'elm make --docs=docs.json',
-      'test:format': 'elm-format src/ preview*/**.elm tests/ --validate',
+      'test:format': 'elm-format src/ preview*/ tests/ --validate',
       'test:run': 'elm-test',
       'test:review': 'elm-review',
       'test:package': 'node elm-review-package-tests/check-previews-compile.js',

--- a/test/snapshots/elm-review-something-for-new-rule/package.json
+++ b/test/snapshots/elm-review-something-for-new-rule/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "test": "npm-run-all --print-name --silent --sequential test:make test:format test:run test:review test:package",
     "test:make": "elm make --docs=docs.json",
-    "test:format": "elm-format src/ preview*/**.elm tests/ --validate",
+    "test:format": "elm-format src/ preview*/ tests/ --validate",
     "test:run": "elm-test",
     "test:review": "elm-review",
     "test:package": "node elm-review-package-tests/check-previews-compile.js",

--- a/test/snapshots/elm-review-something-for-new-rule/package.json
+++ b/test/snapshots/elm-review-something-for-new-rule/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "test": "npm-run-all --print-name --silent --sequential test:make test:format test:run test:review test:package",
     "test:make": "elm make --docs=docs.json",
-    "test:format": "elm-format src/ tests/ --validate",
+    "test:format": "elm-format src/ preview*/**.elm tests/ --validate",
     "test:run": "elm-test",
     "test:review": "elm-review",
     "test:package": "node elm-review-package-tests/check-previews-compile.js",

--- a/test/snapshots/elm-review-something/package.json
+++ b/test/snapshots/elm-review-something/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "test": "npm-run-all --print-name --silent --sequential test:make test:format test:run test:review test:package",
     "test:make": "elm make --docs=docs.json",
-    "test:format": "elm-format src/ preview*/**.elm tests/ --validate",
+    "test:format": "elm-format src/ preview*/ tests/ --validate",
     "test:run": "elm-test",
     "test:review": "elm-review",
     "test:package": "node elm-review-package-tests/check-previews-compile.js",

--- a/test/snapshots/elm-review-something/package.json
+++ b/test/snapshots/elm-review-something/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "test": "npm-run-all --print-name --silent --sequential test:make test:format test:run test:review test:package",
     "test:make": "elm make --docs=docs.json",
-    "test:format": "elm-format src/ tests/ --validate",
+    "test:format": "elm-format src/ preview*/**.elm tests/ --validate",
     "test:run": "elm-test",
     "test:review": "elm-review",
     "test:package": "node elm-review-package-tests/check-previews-compile.js",


### PR DESCRIPTION
Currently, the default tests for packages do not check if the Elm files in e.g. `preview/` are formatted with `elm-format` (though they do check if they compile).  This adds just such a check.

Note that `preview*/**.elm` is used rather than `preview*/`, because otherwise an empty folder will cause it to error-out.  This solution seems to work well for relatively complex preview structures.