### PR TITLE
Bump CI Node.js version to 16, actions/setup-node to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
-        node-version: 15.x
+        node-version: 16.x
 
     - name: Cache ~/.elm
       uses: actions/cache@v2


### PR DESCRIPTION
I was reading your GitHub Actions CI suite, and found these two minor things I think could be upgraded. If not, then please just close the PR 😎 👋 

This PR bumps the `node-version` on CI to `16.x` (latest LTS version) and also bumps the GitHub Action `actions/setup-node` to `v2`

Ref: [Node.js releases](https://nodejs.org/en/about/releases/), [actions/setup-node releases](https://github.com/actions/setup-node/releases)

Thank you for your work on elm-review!