### PR TITLE
Fix `check-previews-compile.js` failure on long JSON output

### DIFF
--- a/new-package/elm-review-package-tests/check-previews-compile.js
+++ b/new-package/elm-review-package-tests/check-previews-compile.js
@@ -21,7 +21,7 @@ function checkThatExampleCompiles(exampleConfiguration) {
   );
 
   try {
-    execSync(`npx elm-review --config ${exampleConfiguration} --report=json`, {
+    execSync('npx elm-review', ['--config', exampleConfiguration, '--report=json'], {
       encoding: 'utf8',
       stdio: 'pipe',
       cwd: path.resolve(__dirname, '..')


### PR DESCRIPTION
Per discussion on the slack, this fixes the issue of JSON output truncating at a certain length.  Why is beyond me and known only to the javascript gods.  Credit to @sparksp for figuring it out.