### PR TITLE
Fix watch issue on Windows

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -7,6 +7,7 @@ const Anonymize = require('./anonymize');
 const AppState = require('./state');
 const Runner = require('./runner');
 const SuppressedErrors = require('./suppressed-errors');
+const OsHelpers = require('./os-helpers');
 
 const fsReadFile = util.promisify(fs.readFile);
 const fsReadJson = util.promisify(fs.readJson);
@@ -48,7 +49,7 @@ function watchFiles(
   }
 
   const elmJsonWatcher = chokidar
-    .watch(removeWindowsSeparators(options.elmJsonPath), {ignoreInitial: true})
+    .watch(OsHelpers.makePathOsAgnostic(options.elmJsonPath), {ignoreInitial: true})
     .on('change', async () => {
       const newValue = await fsReadJson(options.elmJsonPath);
       if (JSON.stringify(newValue) !== JSON.stringify(elmJsonContent)) {
@@ -90,7 +91,7 @@ function watchFiles(
     });
 
   const readmeWatcher = chokidar
-    .watch(removeWindowsSeparators(options.readmePath), {ignoreInitial: true})
+    .watch(OsHelpers.makePathOsAgnostic(options.readmePath), {ignoreInitial: true})
     .on('add', async () => {
       Debug.log('README.md has been added');
 
@@ -121,7 +122,7 @@ function watchFiles(
   const fileWatcher = chokidar
     .watch(
       sourceDirectories.map((directory) =>
-        removeWindowsSeparators(`${directory}/**/*.elm`)
+        OsHelpers.makePathOsAgnostic(`${directory}/**/*.elm`)
       ),
       {
         ignored: [
@@ -134,7 +135,7 @@ function watchFiles(
       }
     )
     .on('add', async (absolutePath) => {
-      const relativePath = path.relative(process.cwd(), absolutePath);
+      const relativePath = OsHelpers.makePathOsAgnostic(path.relative(process.cwd(), absolutePath));
 
       Debug.log(`File ${Anonymize.path(options, relativePath)} has been added`);
 
@@ -166,7 +167,7 @@ function watchFiles(
       runReview();
     })
     .on('change', async (absolutePath) => {
-      const relativePath = path.relative(process.cwd(), absolutePath);
+      const relativePath = OsHelpers.makePathOsAgnostic(path.relative(process.cwd(), absolutePath));
 
       let elmFile = AppState.getFileFromMemoryCache(relativePath);
       if (!elmFile) {
@@ -192,7 +193,7 @@ function watchFiles(
       }
     })
     .on('unlink', (absolutePath) => {
-      const relativePath = path.relative(process.cwd(), absolutePath);
+      const relativePath = OsHelpers.makePathOsAgnostic(path.relative(process.cwd(), absolutePath));
       Debug.log(
         `File ${Anonymize.path(options, relativePath)} has been removed`
       );
@@ -218,7 +219,7 @@ function watchFiles(
 
   const suppressedErrorsWatcher = chokidar
     .watch(
-      removeWindowsSeparators(`${options.suppressedErrorsFolder()}/*.json`),
+      OsHelpers.makePathOsAgnostic(`${options.suppressedErrorsFolder()}/*.json`),
       {ignoreInitial: true}
     )
     .on('add', updateSuppressedErrors)
@@ -257,7 +258,7 @@ function watchConfiguration(
       (directory) => path.resolve(options.userSrc(), directory) + '/**/*.elm'
     )
     .concat([reviewElmJsonPath])
-    .map(removeWindowsSeparators);
+    .map(OsHelpers.makePathOsAgnostic);
 
   const configurationWatcher = chokidar
     .watch(configurationPaths, {ignoreInitial: true})
@@ -286,10 +287,6 @@ function clearConsole() {
       ? '\u001B[2J\u001B[0f'
       : '\u001B[2J\u001B[3J\u001B[H'
   );
-}
-
-function removeWindowsSeparators(string) {
-  return string.replace(/.:/, '').replace(/\\/g, '/');
 }
 
 module.exports = {


### PR DESCRIPTION
When running `elm-review --watch` on Windows, the first review works successfully, but after a change is made to a file, the following error occurs:

```
-- ELM-REVIEW ERROR ----------------------------------------------- GLOBAL ERROR

: Found several modules named `Views.Example.Main`

I found several modules with the name `Views.Example.Main`. Depending on how
I choose to resolve this, I might give you different reports. Since this is a
compiler error anyway, I require this problem to be solved. Please fix this then
try running `elm-review` again.

Here are the paths to some of the files that share a module name:
- Website/DesktopModules/MVC/Example/Views/Example/Main.elm
- Website\DesktopModules\MVC\Example\Views\Example\Main.elm

It is possible that you requested me to look at several projects, and that
modules from each project share the same name. I don't recommend reviewing
several projects at the same time, as I can only handle one `elm.json`.
```

It appears that the first run uses file paths that have been made OS-agnostic (i.e. which uses `/` instead of `\`), but the path from the watcher is not made OS-agnostic, so it creates a situation where elm-review thinks the same file is at two different paths.

The initial loading of files in `elm-files.js` calls `OsHelpers.makePathOsAgnostic` on the path.
https://github.com/jfmengels/node-elm-review/blob/d35e8211148a9abefb95a64d1985027a8dd33883/lib/elm-files.js#L158-L163

This function matches the `removeWindowsSeparators` function in `watch.js`, so I replaced its usages, as well as adding usages that were missing.
https://github.com/jfmengels/node-elm-review/blob/d35e8211148a9abefb95a64d1985027a8dd33883/lib/os-helpers.js#L1-L3
https://github.com/jfmengels/node-elm-review/blob/d35e8211148a9abefb95a64d1985027a8dd33883/lib/watch.js#L291-L293