### PR TITLE
Get the Elm version from the review/elm.json file

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -9,7 +9,6 @@ const ErrorMessage = require('./error-message');
 const {getProjectFiles} = require('./elm-files');
 const SuppressedErrors = require('./suppressed-errors');
 const projectDependencies = require('./project-dependencies');
-const {getElmBinary, getElmVersion} = require('./elm-binary');
 const {runReview, startReview, requestReview} = require('./run-review');
 
 function sendProjectContent(
@@ -117,15 +116,16 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
     reviewElmJson.dependencies.direct['stil4m/elm-syntax'] ||
     reviewElmJson.dependencies.indirect['stil4m/elm-syntax'];
 
+  const elmVersion = reviewElmJson['elm-version'];
+
   const [
     {elmJsonData, elmFiles, sourceDirectories, readme},
-    suppressedErrors,
-    elmVersion
+    suppressedErrors
   ] = await Promise.all([
     getProjectFiles(options, elmSyntaxVersion),
-    SuppressedErrors.read(options),
-    getElmBinary(options).then(getElmVersion)
+    SuppressedErrors.read(options)
   ]);
+
   const {projectDeps, linksToRuleDocs} = await projectDependencies.collect(
     options,
     elmJsonData.project,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -118,20 +118,21 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
 
   const elmVersion = reviewElmJson['elm-version'];
 
-  const [
-    {elmJsonData, elmFiles, sourceDirectories, readme},
-    suppressedErrors
-  ] = await Promise.all([
-    getProjectFiles(options, elmSyntaxVersion),
-    SuppressedErrors.read(options)
-  ]);
+  const suppressedErrors = SuppressedErrors.read(options);
 
+  const {
+    elmJsonData,
+    elmFiles,
+    sourceDirectories,
+    readme
+  } = await getProjectFiles(options, elmSyntaxVersion);
   const {projectDeps, linksToRuleDocs} = await projectDependencies.collect(
     options,
     elmJsonData.project,
     reviewElmJson.dependencies.direct,
     elmVersion
   );
+
   await sendProjectContent(
     options,
     app,
@@ -139,7 +140,7 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
     readme,
     elmFiles,
     projectDeps,
-    suppressedErrors,
+    await suppressedErrors,
     linksToRuleDocs
   );
 

--- a/test/run-snapshots/elm-review-something-for-new-rule/elm-tooling.json
+++ b/test/run-snapshots/elm-review-something-for-new-rule/elm-tooling.json
@@ -1,7 +1,7 @@
 {
     "tools": {
         "elm": "0.19.1",
-        "elm-format": "0.8.6",
+        "elm-format": "0.8.7",
         "elm-json": "0.2.13"
     }
 }

--- a/test/run-snapshots/elm-review-something/elm-tooling.json
+++ b/test/run-snapshots/elm-review-something/elm-tooling.json
@@ -1,7 +1,7 @@
 {
     "tools": {
         "elm": "0.19.1",
-        "elm-format": "0.8.6",
+        "elm-format": "0.8.7",
         "elm-json": "0.2.13"
     }
 }


### PR DESCRIPTION
This should be a lot faster that to find the elm compiler and spawn it to get the Elm version