### PR TITLE
Separate fetching rule links and project dependencies

### DIFF
--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -1,13 +1,4 @@
-const path = require('path');
-const os = require('os');
 const ProjectJsonFiles = require('./project-json-files');
-
-const elmRoot =
-  process.env.ELM_HOME ||
-  path.join(
-    os.homedir(),
-    os.platform() === 'win32' ? 'AppData/Roaming/elm' : '.elm'
-  );
 
 async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
   const dependenciesEntries =
@@ -23,17 +14,6 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
           ...elmJson['test-dependencies']
         };
 
-  const elmReviewDependencyCache = (name, packageVersion) =>
-    path.join(
-      elmRoot,
-      'elm-review',
-      options.packageJsonVersion,
-      'packages',
-      elmVersion,
-      name,
-      packageVersion
-    );
-
   // Mutated in the computation of `projectDepsPromises` below
   let hasDependenciesThatCouldNotBeDownloaded = false;
 
@@ -45,7 +25,6 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
         ProjectJsonFiles.getDocsJson(
           options,
           elmVersion,
-          elmReviewDependencyCache(name, packageVersion),
           name,
           packageVersion
         ).catch(() => {
@@ -55,7 +34,6 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
         ProjectJsonFiles.getElmJson(
           options,
           elmVersion,
-          elmReviewDependencyCache(name, packageVersion),
           name,
           packageVersion
         ).catch(() => {

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -212,26 +212,10 @@ async function collectRuleLinks(options, elmJson, reviewDirectDependencies, elmV
     )
   ]);
 
-  const linksToRuleDocs = computeLinksToRuleDocs(
+  return computeLinksToRuleDocs(
     reviewDirectDependencies,
     elmJsonForReviewDependencies
   );
-
-  if (hasDependenciesThatCouldNotBeDownloaded && options.report !== 'json') {
-    console.log(
-      `
-I could not fetch all the data I need about your project’s dependencies. Please
-connect to the Internet so I can download and cache the data for future uses.
-I will try to review the project anyway, but you might get unexpected results…
-`.trim(),
-      '\n'
-    );
-  }
-
-  return {
-    projectDeps,
-    linksToRuleDocs
-  };
 }
 
 function computeLinksToRuleDocs(

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -12,15 +12,128 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
   const dependenciesEntries =
     elmJson.type === 'application'
       ? {
-          ...elmJson.dependencies.direct,
-          ...elmJson.dependencies.indirect,
-          ...elmJson['test-dependencies'].direct,
-          ...elmJson['test-dependencies'].indirect
-        }
+        ...elmJson.dependencies.direct,
+        ...elmJson.dependencies.indirect,
+        ...elmJson['test-dependencies'].direct,
+        ...elmJson['test-dependencies'].indirect
+      }
       : {
-          ...elmJson.dependencies,
-          ...elmJson['test-dependencies']
-        };
+        ...elmJson.dependencies,
+        ...elmJson['test-dependencies']
+      };
+
+  const elmRoot =
+    process.env.ELM_HOME ||
+    path.join(
+      os.homedir(),
+      os.platform() === 'win32' ? 'AppData/Roaming/elm' : '.elm'
+    );
+
+  const directory = (name, packageVersion) =>
+    path.join(elmRoot, elmVersion, 'packages', name, packageVersion);
+
+  const elmReviewDependencyCache = (name, packageVersion) =>
+    path.join(
+      elmRoot,
+      'elm-review',
+      options.packageJsonVersion,
+      'packages',
+      elmVersion,
+      name,
+      packageVersion
+    );
+
+  // Mutated in the computation of `projectDepsPromises` below
+  let hasDependenciesThatCouldNotBeDownloaded = false;
+
+  const projectDepsPromises = Object.entries(dependenciesEntries).map(
+    async ([name, constraint]) => {
+      const packageVersion = constraint.split(' ')[0];
+
+      const [docsJson, dependencyElmJson] = await Promise.all([
+        getDocsJson(
+          directory(name, packageVersion),
+          elmReviewDependencyCache(name, packageVersion),
+          name,
+          packageVersion
+        ).catch(() => {
+          hasDependenciesThatCouldNotBeDownloaded = true;
+          return [];
+        }),
+        getElmJson(
+          directory(name, packageVersion),
+          elmReviewDependencyCache(name, packageVersion),
+          name,
+          packageVersion
+        ).catch(() => {
+          hasDependenciesThatCouldNotBeDownloaded = true;
+          return defaultElmJson(name, packageVersion);
+        })
+      ]);
+
+      return {
+        name,
+        docsJson,
+        elmJson: dependencyElmJson
+      };
+    }
+  );
+
+  const elmJsonForReviewDependenciesPromises = Object.entries(
+    reviewDirectDependencies
+  )
+    .filter(([name]) => !(name in dependenciesEntries))
+    .map(([name, packageVersion]) =>
+      getElmJson(
+        directory(name, packageVersion),
+        elmReviewDependencyCache(name, packageVersion),
+        name,
+        packageVersion
+      ).catch(() => null)
+    );
+
+  const [projectDeps, elmJsonForReviewDependencies] = await Promise.all([
+    Promise.all(projectDepsPromises).then((items) => items.filter(Boolean)),
+    Promise.all(elmJsonForReviewDependenciesPromises).then((items) =>
+      items.filter(Boolean)
+    )
+  ]);
+
+  const linksToRuleDocs = computeLinksToRuleDocs(
+    reviewDirectDependencies,
+    elmJsonForReviewDependencies
+  );
+
+  if (hasDependenciesThatCouldNotBeDownloaded && options.report !== 'json') {
+    console.log(
+      `
+I could not fetch all the data I need about your project’s dependencies. Please
+connect to the Internet so I can download and cache the data for future uses.
+I will try to review the project anyway, but you might get unexpected results…
+`.trim(),
+      '\n'
+    );
+  }
+
+  return {
+    projectDeps,
+    linksToRuleDocs
+  };
+}
+
+async function collectRuleLinks(options, elmJson, reviewDirectDependencies, elmVersion) {
+  const dependenciesEntries =
+    elmJson.type === 'application'
+      ? {
+        ...elmJson.dependencies.direct,
+        ...elmJson.dependencies.indirect,
+        ...elmJson['test-dependencies'].direct,
+        ...elmJson['test-dependencies'].indirect
+      }
+      : {
+        ...elmJson.dependencies,
+        ...elmJson['test-dependencies']
+      };
 
   const elmRoot =
     process.env.ELM_HOME ||

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -19,15 +19,15 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
   const dependenciesEntries =
     elmJson.type === 'application'
       ? {
-        ...elmJson.dependencies.direct,
-        ...elmJson.dependencies.indirect,
-        ...elmJson['test-dependencies'].direct,
-        ...elmJson['test-dependencies'].indirect
-      }
+          ...elmJson.dependencies.direct,
+          ...elmJson.dependencies.indirect,
+          ...elmJson['test-dependencies'].direct,
+          ...elmJson['test-dependencies'].indirect
+        }
       : {
-        ...elmJson.dependencies,
-        ...elmJson['test-dependencies']
-      };
+          ...elmJson.dependencies,
+          ...elmJson['test-dependencies']
+        };
 
   const directory = (name, packageVersion) =>
     path.join(elmRoot, elmVersion, 'packages', name, packageVersion);

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -221,14 +221,24 @@ function getDocsJson(
 }
 
 function getElmJson(directory, elmReviewDependencyCache, name, packageVersion) {
-  return fsReadJson(path.join(directory, 'elm.json'))
-    .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'elm.json')))
-    .catch(() =>
-      readElmJsonFromPackagesWebsite(name, packageVersion).then((result) => {
-        cacheFile(elmReviewDependencyCache, 'elm.json', result).catch(() => {});
-        return result;
-      })
-    );
+  // Look for the dependency in ELM_HOME first
+  return (
+    fsReadJson(path.join(directory, 'elm.json'))
+      // Then in the dependency cache for elm-review
+      .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'elm.json')))
+      .catch(() =>
+        // Finally, try to download it from the packages website
+        readElmJsonFromPackagesWebsite(name, packageVersion).then((result) => {
+          // And cache it for future uses
+          cacheFile(
+            elmReviewDependencyCache,
+            'elm.json',
+            result
+          ).catch(() => {});
+          return result;
+        })
+      )
+  );
 }
 
 async function cacheFile(directory, name, jsonContent) {

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -43,6 +43,7 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
 
       const [docsJson, dependencyElmJson] = await Promise.all([
         ProjectJsonFiles.getDocsJson(
+          options,
           elmVersion,
           elmReviewDependencyCache(name, packageVersion),
           name,
@@ -52,6 +53,7 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
           return [];
         }),
         ProjectJsonFiles.getElmJson(
+          options,
           elmVersion,
           elmReviewDependencyCache(name, packageVersion),
           name,

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -1,5 +1,9 @@
 const ProjectJsonFiles = require('./project-json-files');
 
+module.exports = {
+  collect
+};
+
 async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
   const dependenciesEntries =
     elmJson.type === 'application'
@@ -68,63 +72,6 @@ I will try to review the project anyway, but you might get unexpected results…
   return projectDeps;
 }
 
-async function collectRuleLinks(reviewDirectDependencies, elmVersion) {
-  const elmJsonForReviewDependenciesPromises = Object.entries(
-    reviewDirectDependencies
-  )
-    .filter(([name]) => !name.startsWith('elm/'))
-    .map(([name, packageVersion]) =>
-      ProjectJsonFiles.getElmJsonFromElmHome(
-        elmVersion,
-        name,
-        packageVersion
-      ).catch(() => null)
-    );
-
-  const elmJsonForReviewDependencies = await Promise.all(
-    elmJsonForReviewDependenciesPromises
-  ).then((items) => items.filter(Boolean));
-
-  return computeLinksToRuleDocs(
-    reviewDirectDependencies,
-    elmJsonForReviewDependencies
-  );
-}
-
-function computeLinksToRuleDocs(
-  reviewDirectDependencies,
-  elmJsonForReviewDependencies
-) {
-  return Object.entries(reviewDirectDependencies).reduce(
-    (acc, [depName, packageVersion]) => {
-      const dep = elmJsonForReviewDependencies.find(
-        (elmJson) => elmJson.name === depName
-      );
-
-      if (!dep || !('jfmengels/elm-review' in dep.dependencies)) {
-        return acc;
-      }
-
-      const exposedModules = Array.isArray(dep['exposed-modules'])
-        ? dep['exposed-modules']
-        : Object.values(dep['exposed-modules']).reduce((acc, items) =>
-            acc.concat(items)
-          );
-
-      exposedModules.forEach((moduleName) => {
-        acc[moduleName] = linkToModule(depName, packageVersion, moduleName);
-      });
-      return acc;
-    },
-    {}
-  );
-}
-
-function linkToModule(dependencyName, packageVersion, moduleName) {
-  const urlModuleName = moduleName.split('.').join('-');
-  return `https://package.elm-lang.org/packages/${dependencyName}/${packageVersion}/${urlModuleName}`;
-}
-
 function defaultElmJson(name, packageVersion) {
   return {
     type: 'package',
@@ -141,8 +88,3 @@ function defaultElmJson(name, packageVersion) {
     'test-dependencies': {}
   };
 }
-
-module.exports = {
-  collect,
-  collectRuleLinks
-};

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -23,9 +23,6 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
           ...elmJson['test-dependencies']
         };
 
-  const directory = (name, packageVersion) =>
-    path.join(elmRoot, elmVersion, 'packages', name, packageVersion);
-
   const elmReviewDependencyCache = (name, packageVersion) =>
     path.join(
       elmRoot,
@@ -46,7 +43,7 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
 
       const [docsJson, dependencyElmJson] = await Promise.all([
         ProjectJsonFiles.getDocsJson(
-          directory(name, packageVersion),
+          elmVersion,
           elmReviewDependencyCache(name, packageVersion),
           name,
           packageVersion

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -279,5 +279,6 @@ async function readElmJsonFromPackagesWebsite(packageName, packageVersion) {
 }
 
 module.exports = {
-  collect
+  collect,
+  collectRuleLinks
 };

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -79,30 +79,7 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
     }
   );
 
-  const elmJsonForReviewDependenciesPromises = Object.entries(
-    reviewDirectDependencies
-  )
-    .filter(([name]) => !(name in dependenciesEntries))
-    .map(([name, packageVersion]) =>
-      getElmJson(
-        elmVersion,
-        elmReviewDependencyCache(name, packageVersion),
-        name,
-        packageVersion
-      ).catch(() => null)
-    );
-
-  const [projectDeps, elmJsonForReviewDependencies] = await Promise.all([
-    Promise.all(projectDepsPromises).then((items) => items.filter(Boolean)),
-    Promise.all(elmJsonForReviewDependenciesPromises).then((items) =>
-      items.filter(Boolean)
-    )
-  ]);
-
-  const linksToRuleDocs = computeLinksToRuleDocs(
-    reviewDirectDependencies,
-    elmJsonForReviewDependencies
-  );
+  const projectDeps = await Promise.all(projectDepsPromises).then((items) => items.filter(Boolean));
 
   if (hasDependenciesThatCouldNotBeDownloaded && options.report !== 'json') {
     console.log(
@@ -115,10 +92,7 @@ I will try to review the project anyway, but you might get unexpected results…
     );
   }
 
-  return {
-    projectDeps,
-    linksToRuleDocs
-  };
+  return projectDeps;
 }
 
 async function collectRuleLinks(reviewDirectDependencies, elmVersion) {

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -121,20 +121,7 @@ I will try to review the project anyway, but you might get unexpected results…
   };
 }
 
-async function collectRuleLinks(options, elmJson, reviewDirectDependencies, elmVersion) {
-  const dependenciesEntries =
-    elmJson.type === 'application'
-      ? {
-        ...elmJson.dependencies.direct,
-        ...elmJson.dependencies.indirect,
-        ...elmJson['test-dependencies'].direct,
-        ...elmJson['test-dependencies'].indirect
-      }
-      : {
-        ...elmJson.dependencies,
-        ...elmJson['test-dependencies']
-      };
-
+async function collectRuleLinks(options, reviewDirectDependencies, elmVersion) {
   const elmRoot =
     process.env.ELM_HOME ||
     path.join(
@@ -159,7 +146,7 @@ async function collectRuleLinks(options, elmJson, reviewDirectDependencies, elmV
   const elmJsonForReviewDependenciesPromises = Object.entries(
     reviewDirectDependencies
   )
-    .filter(([name]) => !(name in dependenciesEntries))
+    .filter(([name]) => !name.startsWith('elm/'))
     .map(([name, packageVersion]) =>
       getElmJson(
         directory(name, packageVersion),

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -121,32 +121,13 @@ I will try to review the project anyway, but you might get unexpected results…
   };
 }
 
-async function collectRuleLinks(options, reviewDirectDependencies, elmVersion) {
-  const directory = (name, packageVersion) =>
-    path.join(elmRoot, elmVersion, 'packages', name, packageVersion);
-
-  const elmReviewDependencyCache = (name, packageVersion) =>
-    path.join(
-      elmRoot,
-      'elm-review',
-      options.packageJsonVersion,
-      'packages',
-      elmVersion,
-      name,
-      packageVersion
-    );
-
+async function collectRuleLinks(reviewDirectDependencies, elmVersion) {
   const elmJsonForReviewDependenciesPromises = Object.entries(
     reviewDirectDependencies
   )
     .filter(([name]) => !name.startsWith('elm/'))
     .map(([name, packageVersion]) =>
-      getElmJson(
-        elmVersion,
-        elmReviewDependencyCache(name, packageVersion),
-        name,
-        packageVersion
-      ).catch(() => null)
+      getElmJsonFromElmHome(elmVersion, name, packageVersion).catch(() => null)
     );
 
   const elmJsonForReviewDependencies = await Promise.all(

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -61,7 +61,7 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
           return [];
         }),
         getElmJson(
-          directory(name, packageVersion),
+          elmVersion,
           elmReviewDependencyCache(name, packageVersion),
           name,
           packageVersion
@@ -85,7 +85,7 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
     .filter(([name]) => !(name in dependenciesEntries))
     .map(([name, packageVersion]) =>
       getElmJson(
-        directory(name, packageVersion),
+        elmVersion,
         elmReviewDependencyCache(name, packageVersion),
         name,
         packageVersion
@@ -142,7 +142,7 @@ async function collectRuleLinks(options, reviewDirectDependencies, elmVersion) {
     .filter(([name]) => !name.startsWith('elm/'))
     .map(([name, packageVersion]) =>
       getElmJson(
-        directory(name, packageVersion),
+        elmVersion,
         elmReviewDependencyCache(name, packageVersion),
         name,
         packageVersion
@@ -213,10 +213,15 @@ function getDocsJson(
     );
 }
 
-function getElmJson(directory, elmReviewDependencyCache, name, packageVersion) {
+function getElmJson(
+  elmVersion,
+  elmReviewDependencyCache,
+  name,
+  packageVersion
+) {
   // Look for the dependency in ELM_HOME first
   return (
-    fsReadJson(path.join(directory, 'elm.json'))
+    getElmJsonFromElmHome(elmVersion, name, packageVersion)
       // Then in the dependency cache for elm-review
       .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'elm.json')))
       .catch(() =>
@@ -232,6 +237,28 @@ function getElmJson(directory, elmReviewDependencyCache, name, packageVersion) {
         })
       )
   );
+}
+
+// TODO Empty this cache at some point?
+// Note that we might need it in watch and fix mode, but not otherwise.
+const elmJsonInElmHomePromises = new Map();
+function getElmJsonFromElmHome(elmVersion, name, packageVersion) {
+  const key = `${elmVersion}-${name}-${packageVersion}`;
+  let promise = elmJsonInElmHomePromises.get(key);
+  if (promise) {
+    return promise;
+  }
+
+  const directory = path.join(
+    elmRoot,
+    elmVersion,
+    'packages',
+    name,
+    packageVersion
+  );
+  promise = fsReadJson(path.join(directory, 'elm.json'));
+  elmJsonInElmHomePromises.set(key, promise);
+  return promise;
 }
 
 async function cacheFile(directory, name, jsonContent) {

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -156,42 +156,6 @@ async function collectRuleLinks(options, elmJson, reviewDirectDependencies, elmV
       packageVersion
     );
 
-  // Mutated in the computation of `projectDepsPromises` below
-  let hasDependenciesThatCouldNotBeDownloaded = false;
-
-  const projectDepsPromises = Object.entries(dependenciesEntries).map(
-    async ([name, constraint]) => {
-      const packageVersion = constraint.split(' ')[0];
-
-      const [docsJson, dependencyElmJson] = await Promise.all([
-        getDocsJson(
-          directory(name, packageVersion),
-          elmReviewDependencyCache(name, packageVersion),
-          name,
-          packageVersion
-        ).catch(() => {
-          hasDependenciesThatCouldNotBeDownloaded = true;
-          return [];
-        }),
-        getElmJson(
-          directory(name, packageVersion),
-          elmReviewDependencyCache(name, packageVersion),
-          name,
-          packageVersion
-        ).catch(() => {
-          hasDependenciesThatCouldNotBeDownloaded = true;
-          return defaultElmJson(name, packageVersion);
-        })
-      ]);
-
-      return {
-        name,
-        docsJson,
-        elmJson: dependencyElmJson
-      };
-    }
-  );
-
   const elmJsonForReviewDependenciesPromises = Object.entries(
     reviewDirectDependencies
   )
@@ -205,12 +169,9 @@ async function collectRuleLinks(options, elmJson, reviewDirectDependencies, elmV
       ).catch(() => null)
     );
 
-  const [projectDeps, elmJsonForReviewDependencies] = await Promise.all([
-    Promise.all(projectDepsPromises).then((items) => items.filter(Boolean)),
-    Promise.all(elmJsonForReviewDependenciesPromises).then((items) =>
-      items.filter(Boolean)
-    )
-  ]);
+  const elmJsonForReviewDependencies = await Promise.all(
+    elmJsonForReviewDependenciesPromises
+  ).then((items) => items.filter(Boolean));
 
   return computeLinksToRuleDocs(
     reviewDirectDependencies,

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -101,7 +101,6 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
 
   const linksToRuleDocs = computeLinksToRuleDocs(
     reviewDirectDependencies,
-    projectDeps,
     elmJsonForReviewDependencies
   );
 
@@ -124,7 +123,6 @@ I will try to review the project anyway, but you might get unexpected results…
 
 function computeLinksToRuleDocs(
   reviewDirectDependencies,
-  projectDeps,
   elmJsonForReviewDependencies
 ) {
   return Object.entries(reviewDirectDependencies).reduce(

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -8,6 +8,13 @@ const fsMkdirp = util.promisify(fs.mkdirp);
 const fsReadJson = util.promisify(fs.readJson);
 const fsWriteJson = util.promisify(fs.writeJson);
 
+const elmRoot =
+  process.env.ELM_HOME ||
+  path.join(
+    os.homedir(),
+    os.platform() === 'win32' ? 'AppData/Roaming/elm' : '.elm'
+  );
+
 async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
   const dependenciesEntries =
     elmJson.type === 'application'
@@ -21,13 +28,6 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
         ...elmJson.dependencies,
         ...elmJson['test-dependencies']
       };
-
-  const elmRoot =
-    process.env.ELM_HOME ||
-    path.join(
-      os.homedir(),
-      os.platform() === 'win32' ? 'AppData/Roaming/elm' : '.elm'
-    );
 
   const directory = (name, packageVersion) =>
     path.join(elmRoot, elmVersion, 'packages', name, packageVersion);
@@ -122,13 +122,6 @@ I will try to review the project anyway, but you might get unexpected results…
 }
 
 async function collectRuleLinks(options, reviewDirectDependencies, elmVersion) {
-  const elmRoot =
-    process.env.ELM_HOME ||
-    path.join(
-      os.homedir(),
-      os.platform() === 'win32' ? 'AppData/Roaming/elm' : '.elm'
-    );
-
   const directory = (name, packageVersion) =>
     path.join(elmRoot, elmVersion, 'packages', name, packageVersion);
 

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -1,13 +1,6 @@
 const path = require('path');
-const util = require('util');
 const os = require('os');
-const got = require('got');
-const fs = require('fs-extra');
 const ProjectJsonFiles = require('./project-json-files');
-
-const fsMkdirp = util.promisify(fs.mkdirp);
-const fsReadJson = util.promisify(fs.readJson);
-const fsWriteJson = util.promisify(fs.writeJson);
 
 const elmRoot =
   process.env.ELM_HOME ||
@@ -52,7 +45,7 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
       const packageVersion = constraint.split(' ')[0];
 
       const [docsJson, dependencyElmJson] = await Promise.all([
-        getDocsJson(
+        ProjectJsonFiles.getDocsJson(
           directory(name, packageVersion),
           elmReviewDependencyCache(name, packageVersion),
           name,
@@ -155,31 +148,6 @@ function linkToModule(dependencyName, packageVersion, moduleName) {
   return `https://package.elm-lang.org/packages/${dependencyName}/${packageVersion}/${urlModuleName}`;
 }
 
-function getDocsJson(
-  directory,
-  elmReviewDependencyCache,
-  name,
-  packageVersion
-) {
-  return fsReadJson(path.join(directory, 'docs.json'))
-    .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'docs.json')))
-    .catch(() =>
-      readDocsJsonFromPackagesWebsite(name, packageVersion).then((result) => {
-        cacheFile(
-          elmReviewDependencyCache,
-          'docs.json',
-          result
-        ).catch(() => {});
-        return result;
-      })
-    );
-}
-
-async function cacheFile(directory, name, jsonContent) {
-  await fsMkdirp(directory).catch(() => {});
-  return fsWriteJson(path.join(directory, name), jsonContent);
-}
-
 function defaultElmJson(name, packageVersion) {
   return {
     type: 'package',
@@ -195,13 +163,6 @@ function defaultElmJson(name, packageVersion) {
     },
     'test-dependencies': {}
   };
-}
-
-async function readDocsJsonFromPackagesWebsite(packageName, packageVersion) {
-  const response = await got(
-    `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/docs.json`
-  );
-  return JSON.parse(response.body);
 }
 
 module.exports = {

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -3,6 +3,7 @@ const util = require('util');
 const os = require('os');
 const got = require('got');
 const fs = require('fs-extra');
+const ProjectJsonFiles = require('./project-json-files');
 
 const fsMkdirp = util.promisify(fs.mkdirp);
 const fsReadJson = util.promisify(fs.readJson);
@@ -60,7 +61,7 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
           hasDependenciesThatCouldNotBeDownloaded = true;
           return [];
         }),
-        getElmJson(
+        ProjectJsonFiles.getElmJson(
           elmVersion,
           elmReviewDependencyCache(name, packageVersion),
           name,
@@ -79,7 +80,9 @@ async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
     }
   );
 
-  const projectDeps = await Promise.all(projectDepsPromises).then((items) => items.filter(Boolean));
+  const projectDeps = await Promise.all(projectDepsPromises).then((items) =>
+    items.filter(Boolean)
+  );
 
   if (hasDependenciesThatCouldNotBeDownloaded && options.report !== 'json') {
     console.log(
@@ -101,7 +104,11 @@ async function collectRuleLinks(reviewDirectDependencies, elmVersion) {
   )
     .filter(([name]) => !name.startsWith('elm/'))
     .map(([name, packageVersion]) =>
-      getElmJsonFromElmHome(elmVersion, name, packageVersion).catch(() => null)
+      ProjectJsonFiles.getElmJsonFromElmHome(
+        elmVersion,
+        name,
+        packageVersion
+      ).catch(() => null)
     );
 
   const elmJsonForReviewDependencies = await Promise.all(
@@ -168,54 +175,6 @@ function getDocsJson(
     );
 }
 
-function getElmJson(
-  elmVersion,
-  elmReviewDependencyCache,
-  name,
-  packageVersion
-) {
-  // Look for the dependency in ELM_HOME first
-  return (
-    getElmJsonFromElmHome(elmVersion, name, packageVersion)
-      // Then in the dependency cache for elm-review
-      .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'elm.json')))
-      .catch(() =>
-        // Finally, try to download it from the packages website
-        readElmJsonFromPackagesWebsite(name, packageVersion).then((result) => {
-          // And cache it for future uses
-          cacheFile(
-            elmReviewDependencyCache,
-            'elm.json',
-            result
-          ).catch(() => {});
-          return result;
-        })
-      )
-  );
-}
-
-// TODO Empty this cache at some point?
-// Note that we might need it in watch and fix mode, but not otherwise.
-const elmJsonInElmHomePromises = new Map();
-function getElmJsonFromElmHome(elmVersion, name, packageVersion) {
-  const key = `${elmVersion}-${name}-${packageVersion}`;
-  let promise = elmJsonInElmHomePromises.get(key);
-  if (promise) {
-    return promise;
-  }
-
-  const directory = path.join(
-    elmRoot,
-    elmVersion,
-    'packages',
-    name,
-    packageVersion
-  );
-  promise = fsReadJson(path.join(directory, 'elm.json'));
-  elmJsonInElmHomePromises.set(key, promise);
-  return promise;
-}
-
 async function cacheFile(directory, name, jsonContent) {
   await fsMkdirp(directory).catch(() => {});
   return fsWriteJson(path.join(directory, name), jsonContent);
@@ -241,13 +200,6 @@ function defaultElmJson(name, packageVersion) {
 async function readDocsJsonFromPackagesWebsite(packageName, packageVersion) {
   const response = await got(
     `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/docs.json`
-  );
-  return JSON.parse(response.body);
-}
-
-async function readElmJsonFromPackagesWebsite(packageName, packageVersion) {
-  const response = await got(
-    `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/elm.json`
   );
   return JSON.parse(response.body);
 }

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -129,17 +129,9 @@ function computeLinksToRuleDocs(
 ) {
   return Object.entries(reviewDirectDependencies).reduce(
     (acc, [depName, packageVersion]) => {
-      let dep = projectDeps.find(
-        (dep) => dep.elmJson && dep.elmJson.name === depName
+      const dep = elmJsonForReviewDependencies.find(
+        (elmJson) => elmJson.name === depName
       );
-
-      if (dep) {
-        dep = dep.elmJson;
-      } else {
-        dep = elmJsonForReviewDependencies.find(
-          (elmJson) => elmJson.name === depName
-        );
-      }
 
       if (!dep || !('jfmengels/elm-review' in dep.dependencies)) {
         return acc;

--- a/lib/project-json-files.js
+++ b/lib/project-json-files.js
@@ -63,11 +63,6 @@ function getElmJsonFromElmHome(elmVersion, name, packageVersion) {
   return promise;
 }
 
-async function cacheFile(directory, name, jsonContent) {
-  await fsMkdirp(directory).catch(() => {});
-  return fsWriteJson(path.join(directory, name), jsonContent);
-}
-
 async function readElmJsonFromPackagesWebsite(packageName, packageVersion) {
   const response = await got(
     `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/elm.json`
@@ -75,7 +70,40 @@ async function readElmJsonFromPackagesWebsite(packageName, packageVersion) {
   return JSON.parse(response.body);
 }
 
+function getDocsJson(
+  directory,
+  elmReviewDependencyCache,
+  name,
+  packageVersion
+) {
+  return fsReadJson(path.join(directory, 'docs.json'))
+    .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'docs.json')))
+    .catch(() =>
+      readDocsJsonFromPackagesWebsite(name, packageVersion).then((result) => {
+        cacheFile(
+          elmReviewDependencyCache,
+          'docs.json',
+          result
+        ).catch(() => {});
+        return result;
+      })
+    );
+}
+
+async function readDocsJsonFromPackagesWebsite(packageName, packageVersion) {
+  const response = await got(
+    `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/docs.json`
+  );
+  return JSON.parse(response.body);
+}
+
+async function cacheFile(directory, name, jsonContent) {
+  await fsMkdirp(directory).catch(() => {});
+  return fsWriteJson(path.join(directory, name), jsonContent);
+}
+
 module.exports = {
   getElmJson,
-  getElmJsonFromElmHome
+  getElmJsonFromElmHome,
+  getDocsJson
 };

--- a/lib/project-json-files.js
+++ b/lib/project-json-files.js
@@ -61,12 +61,21 @@ function getElmJsonFromElmHome(elmVersion, name, packageVersion) {
 }
 
 function getDocsJson(
-  directory,
+  elmVersion,
   elmReviewDependencyCache,
   name,
   packageVersion
 ) {
-  return fsReadJson(path.join(directory, 'docs.json'))
+  return fsReadJson(
+    path.join(
+      elmRoot,
+      elmVersion,
+      'packages',
+      name,
+      packageVersion,
+      'docs.json'
+    )
+  )
     .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'docs.json')))
     .catch(() =>
       readFromPackagesWebsite(

--- a/lib/project-json-files.js
+++ b/lib/project-json-files.js
@@ -28,7 +28,7 @@ function getElmJson(
       .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'elm.json')))
       .catch(() =>
         // Finally, try to download it from the packages website
-        readElmJsonFromPackagesWebsite(name, packageVersion).then((result) => {
+        readFromPackagesWebsite(name, packageVersion, 'elm.json').then((result) => {
           // And cache it for future uses
           cacheFile(
             elmReviewDependencyCache,
@@ -63,13 +63,6 @@ function getElmJsonFromElmHome(elmVersion, name, packageVersion) {
   return promise;
 }
 
-async function readElmJsonFromPackagesWebsite(packageName, packageVersion) {
-  const response = await got(
-    `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/elm.json`
-  );
-  return JSON.parse(response.body);
-}
-
 function getDocsJson(
   directory,
   elmReviewDependencyCache,
@@ -79,7 +72,7 @@ function getDocsJson(
   return fsReadJson(path.join(directory, 'docs.json'))
     .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'docs.json')))
     .catch(() =>
-      readDocsJsonFromPackagesWebsite(name, packageVersion).then((result) => {
+      readFromPackagesWebsite(name, packageVersion, 'docs.json').then((result) => {
         cacheFile(
           elmReviewDependencyCache,
           'docs.json',
@@ -90,9 +83,16 @@ function getDocsJson(
     );
 }
 
-async function readDocsJsonFromPackagesWebsite(packageName, packageVersion) {
+/** Download a file from the Elm package registry.
+ *
+ * @param {string} packageName
+ * @param {string} packageVersion
+ * @param {'elm.json' | 'docs.json'} file
+ * @returns {Promise<object>}
+ */
+async function readFromPackagesWebsite(packageName, packageVersion, file) {
   const response = await got(
-    `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/docs.json`
+    `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/${file}`
   );
   return JSON.parse(response.body);
 }

--- a/lib/project-json-files.js
+++ b/lib/project-json-files.js
@@ -15,6 +15,15 @@ const elmRoot =
     os.platform() === 'win32' ? 'AppData/Roaming/elm' : '.elm'
   );
 
+/** Get the elm.json file for a dependency.
+ *
+ * @param {Options options
+ * @param {string} elmVersion
+ * @param elmReviewDependencyCache
+ * @param {string} name
+ * @param {string} packageVersion
+ * @returns {Promise<Object>}
+ */
 function getElmJson(
   options,
   elmVersion,
@@ -61,6 +70,16 @@ function getElmJsonFromElmHome(elmVersion, name, packageVersion) {
   return promise;
 }
 
+
+/** Get the docs.json file for a dependency.
+ *
+ * @param {Options options
+ * @param {string} elmVersion
+ * @param elmReviewDependencyCache
+ * @param {string} name
+ * @param {string} packageVersion
+ * @returns {Promise<Object>}
+ */
 function getDocsJson(
   options,
   elmVersion,

--- a/lib/project-json-files.js
+++ b/lib/project-json-files.js
@@ -19,31 +19,26 @@ const elmRoot =
  *
  * @param {Options options
  * @param {string} elmVersion
- * @param elmReviewDependencyCache
  * @param {string} name
  * @param {string} packageVersion
  * @returns {Promise<Object>}
  */
-function getElmJson(
-  options,
-  elmVersion,
-  elmReviewDependencyCache,
-  name,
-  packageVersion
-) {
+function getElmJson(options, elmVersion, name, packageVersion) {
+  const cacheLocation = elmReviewDependencyCache(
+    options,
+    elmVersion,
+    name,
+    packageVersion,
+    'elm.json'
+  );
   // Look for the dependency in ELM_HOME first
   return (
     getElmJsonFromElmHome(elmVersion, name, packageVersion)
       // Then in the dependency cache for elm-review
-      .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'elm.json')))
+      .catch(() => fsReadJson(cacheLocation))
       .catch(() =>
         // Finally, try to download it from the packages website
-        readFromPackagesWebsite(
-          elmReviewDependencyCache,
-          name,
-          packageVersion,
-          'elm.json'
-        )
+        readFromPackagesWebsite(cacheLocation, name, packageVersion, 'elm.json')
       )
   );
 }
@@ -70,23 +65,22 @@ function getElmJsonFromElmHome(elmVersion, name, packageVersion) {
   return promise;
 }
 
-
 /** Get the docs.json file for a dependency.
  *
  * @param {Options options
  * @param {string} elmVersion
- * @param elmReviewDependencyCache
  * @param {string} name
  * @param {string} packageVersion
  * @returns {Promise<Object>}
  */
-function getDocsJson(
-  options,
-  elmVersion,
-  elmReviewDependencyCache,
-  name,
-  packageVersion
-) {
+function getDocsJson(options, elmVersion, name, packageVersion) {
+  const cacheLocation = elmReviewDependencyCache(
+    options,
+    elmVersion,
+    name,
+    packageVersion,
+    'docs.json'
+  );
   return fsReadJson(
     path.join(
       elmRoot,
@@ -97,26 +91,22 @@ function getDocsJson(
       'docs.json'
     )
   )
-    .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'docs.json')))
+    .catch(() => fsReadJson(cacheLocation))
     .catch(() =>
-      readFromPackagesWebsite(
-        elmReviewDependencyCache,
-        name,
-        packageVersion,
-        'docs.json'
-      )
+      readFromPackagesWebsite(cacheLocation, name, packageVersion, 'docs.json')
     );
 }
 
 /** Download a file from the Elm package registry.
  *
+ * @param {string} cacheLocation
  * @param {string} packageName
  * @param {string} packageVersion
  * @param {'elm.json' | 'docs.json'} file
  * @returns {Promise<object>}
  */
 async function readFromPackagesWebsite(
-  elmReviewDependencyCache,
+  cacheLocation,
   packageName,
   packageVersion,
   file
@@ -125,13 +115,41 @@ async function readFromPackagesWebsite(
     `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/${file}`
   );
   const json = JSON.parse(response.body);
-  cacheFile(elmReviewDependencyCache, file, json).catch(() => {});
+  cacheFile(cacheLocation, json).catch(() => {});
   return json;
 }
 
-async function cacheFile(directory, name, jsonContent) {
-  await fsMkdirp(directory).catch(() => {});
-  return fsWriteJson(path.join(directory, name), jsonContent);
+async function cacheFile(cacheLocation, json) {
+  await fsMkdirp(path.dirname(cacheLocation)).catch(() => {});
+  return fsWriteJson(cacheLocation, json);
+}
+
+/** Get the path to where a project file would be cached.
+ *
+ * @param {Options} options
+ * @param {string} elmVersion
+ * @param {string} name
+ * @param {string} packageVersion
+ * @param {string} file
+ * @returns {string}
+ */
+function elmReviewDependencyCache(
+  options,
+  elmVersion,
+  name,
+  packageVersion,
+  file
+) {
+  return path.join(
+    elmRoot,
+    'elm-review',
+    options.packageJsonVersion,
+    'packages',
+    elmVersion,
+    name,
+    packageVersion,
+    file
+  );
 }
 
 module.exports = {

--- a/lib/project-json-files.js
+++ b/lib/project-json-files.js
@@ -16,6 +16,7 @@ const elmRoot =
   );
 
 function getElmJson(
+  options,
   elmVersion,
   elmReviewDependencyCache,
   name,
@@ -61,6 +62,7 @@ function getElmJsonFromElmHome(elmVersion, name, packageVersion) {
 }
 
 function getDocsJson(
+  options,
   elmVersion,
   elmReviewDependencyCache,
   name,

--- a/lib/project-json-files.js
+++ b/lib/project-json-files.js
@@ -1,0 +1,81 @@
+const path = require('path');
+const util = require('util');
+const os = require('os');
+const got = require('got');
+const fs = require('fs-extra');
+
+const fsMkdirp = util.promisify(fs.mkdirp);
+const fsReadJson = util.promisify(fs.readJson);
+const fsWriteJson = util.promisify(fs.writeJson);
+
+const elmRoot =
+  process.env.ELM_HOME ||
+  path.join(
+    os.homedir(),
+    os.platform() === 'win32' ? 'AppData/Roaming/elm' : '.elm'
+  );
+
+function getElmJson(
+  elmVersion,
+  elmReviewDependencyCache,
+  name,
+  packageVersion
+) {
+  // Look for the dependency in ELM_HOME first
+  return (
+    getElmJsonFromElmHome(elmVersion, name, packageVersion)
+      // Then in the dependency cache for elm-review
+      .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'elm.json')))
+      .catch(() =>
+        // Finally, try to download it from the packages website
+        readElmJsonFromPackagesWebsite(name, packageVersion).then((result) => {
+          // And cache it for future uses
+          cacheFile(
+            elmReviewDependencyCache,
+            'elm.json',
+            result
+          ).catch(() => {});
+          return result;
+        })
+      )
+  );
+}
+
+// TODO Empty this cache at some point?
+// Note that we might need it in watch and fix mode, but not otherwise.
+const elmJsonInElmHomePromises = new Map();
+function getElmJsonFromElmHome(elmVersion, name, packageVersion) {
+  const key = `${elmVersion}-${name}-${packageVersion}`;
+  let promise = elmJsonInElmHomePromises.get(key);
+  if (promise) {
+    return promise;
+  }
+
+  const directory = path.join(
+    elmRoot,
+    elmVersion,
+    'packages',
+    name,
+    packageVersion
+  );
+  promise = fsReadJson(path.join(directory, 'elm.json'));
+  elmJsonInElmHomePromises.set(key, promise);
+  return promise;
+}
+
+async function cacheFile(directory, name, jsonContent) {
+  await fsMkdirp(directory).catch(() => {});
+  return fsWriteJson(path.join(directory, name), jsonContent);
+}
+
+async function readElmJsonFromPackagesWebsite(packageName, packageVersion) {
+  const response = await got(
+    `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/elm.json`
+  );
+  return JSON.parse(response.body);
+}
+
+module.exports = {
+  getElmJson,
+  getElmJsonFromElmHome
+};

--- a/lib/project-json-files.js
+++ b/lib/project-json-files.js
@@ -28,15 +28,12 @@ function getElmJson(
       .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'elm.json')))
       .catch(() =>
         // Finally, try to download it from the packages website
-        readFromPackagesWebsite(name, packageVersion, 'elm.json').then((result) => {
-          // And cache it for future uses
-          cacheFile(
-            elmReviewDependencyCache,
-            'elm.json',
-            result
-          ).catch(() => {});
-          return result;
-        })
+        readFromPackagesWebsite(
+          elmReviewDependencyCache,
+          name,
+          packageVersion,
+          'elm.json'
+        )
       )
   );
 }
@@ -72,14 +69,12 @@ function getDocsJson(
   return fsReadJson(path.join(directory, 'docs.json'))
     .catch(() => fsReadJson(path.join(elmReviewDependencyCache, 'docs.json')))
     .catch(() =>
-      readFromPackagesWebsite(name, packageVersion, 'docs.json').then((result) => {
-        cacheFile(
-          elmReviewDependencyCache,
-          'docs.json',
-          result
-        ).catch(() => {});
-        return result;
-      })
+      readFromPackagesWebsite(
+        elmReviewDependencyCache,
+        name,
+        packageVersion,
+        'docs.json'
+      )
     );
 }
 
@@ -90,11 +85,18 @@ function getDocsJson(
  * @param {'elm.json' | 'docs.json'} file
  * @returns {Promise<object>}
  */
-async function readFromPackagesWebsite(packageName, packageVersion, file) {
+async function readFromPackagesWebsite(
+  elmReviewDependencyCache,
+  packageName,
+  packageVersion,
+  file
+) {
   const response = await got(
     `https://package.elm-lang.org/packages/${packageName}/${packageVersion}/${file}`
   );
-  return JSON.parse(response.body);
+  const json = JSON.parse(response.body);
+  cacheFile(elmReviewDependencyCache, file, json).catch(() => {});
+  return json;
 }
 
 async function cacheFile(directory, name, jsonContent) {

--- a/lib/review-dependencies.js
+++ b/lib/review-dependencies.js
@@ -1,0 +1,62 @@
+const ProjectJsonFiles = require('./project-json-files');
+
+module.exports = {
+  collectRuleLinks
+};
+
+async function collectRuleLinks(reviewDirectDependencies, elmVersion) {
+  const elmJsonForReviewDependenciesPromises = Object.entries(
+    reviewDirectDependencies
+  )
+    .filter(([name]) => !name.startsWith('elm/'))
+    .map(([name, packageVersion]) =>
+      ProjectJsonFiles.getElmJsonFromElmHome(
+        elmVersion,
+        name,
+        packageVersion
+      ).catch(() => null)
+    );
+
+  const elmJsonForReviewDependencies = await Promise.all(
+    elmJsonForReviewDependenciesPromises
+  ).then((items) => items.filter(Boolean));
+
+  return computeLinksToRuleDocs(
+    reviewDirectDependencies,
+    elmJsonForReviewDependencies
+  );
+}
+
+function computeLinksToRuleDocs(
+  reviewDirectDependencies,
+  elmJsonForReviewDependencies
+) {
+  return Object.entries(reviewDirectDependencies).reduce(
+    (acc, [depName, packageVersion]) => {
+      const dep = elmJsonForReviewDependencies.find(
+        (elmJson) => elmJson.name === depName
+      );
+
+      if (!dep || !('jfmengels/elm-review' in dep.dependencies)) {
+        return acc;
+      }
+
+      const exposedModules = Array.isArray(dep['exposed-modules'])
+        ? dep['exposed-modules']
+        : Object.values(dep['exposed-modules']).reduce((acc, items) =>
+            acc.concat(items)
+          );
+
+      exposedModules.forEach((moduleName) => {
+        acc[moduleName] = linkToModule(depName, packageVersion, moduleName);
+      });
+      return acc;
+    },
+    {}
+  );
+}
+
+function linkToModule(dependencyName, packageVersion, moduleName) {
+  const urlModuleName = moduleName.split('.').join('-');
+  return `https://package.elm-lang.org/packages/${dependencyName}/${packageVersion}/${urlModuleName}`;
+}

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,7 +8,7 @@ const AppWrapper = require('./app-wrapper');
 const ErrorMessage = require('./error-message');
 const {getProjectFiles} = require('./elm-files');
 const SuppressedErrors = require('./suppressed-errors');
-const projectDependencies = require('./project-dependencies');
+const ProjectDependencies = require('./project-dependencies');
 const {runReview, startReview, requestReview} = require('./run-review');
 
 function sendProjectContent(
@@ -126,13 +126,13 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
     sourceDirectories,
     readme
   } = await getProjectFiles(options, elmSyntaxVersion);
-  const {projectDeps} = await projectDependencies.collect(
+  const {projectDeps} = await ProjectDependencies.collect(
     options,
     elmJsonData.project,
     reviewElmJson.dependencies.direct,
     elmVersion
   );
-  const linksToRuleDocs = projectDependencies.collectRuleLinks(
+  const linksToRuleDocs = ProjectDependencies.collectRuleLinks(
     reviewElmJson.dependencies.direct,
     elmVersion
   );

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -126,9 +126,13 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
     sourceDirectories,
     readme
   } = await getProjectFiles(options, elmSyntaxVersion);
-  const {projectDeps, linksToRuleDocs} = await projectDependencies.collect(
+  const {projectDeps} = await projectDependencies.collect(
     options,
     elmJsonData.project,
+    reviewElmJson.dependencies.direct,
+    elmVersion
+  );
+  const linksToRuleDocs = projectDependencies.collectRuleLinks(
     reviewElmJson.dependencies.direct,
     elmVersion
   );
@@ -141,7 +145,7 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
     elmFiles,
     projectDeps,
     await suppressedErrors,
-    linksToRuleDocs
+    await linksToRuleDocs
   );
 
   return {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -118,7 +118,12 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
 
   const elmVersion = reviewElmJson['elm-version'];
 
-  const suppressedErrors = SuppressedErrors.read(options);
+  const suppressedErrorsP = SuppressedErrors.read(options);
+
+  const linksToRuleDocsP = ProjectDependencies.collectRuleLinks(
+    reviewElmJson.dependencies.direct,
+    elmVersion
+  );
 
   const {
     elmJsonData,
@@ -126,16 +131,18 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
     sourceDirectories,
     readme
   } = await getProjectFiles(options, elmSyntaxVersion);
-  const {projectDeps} = await ProjectDependencies.collect(
+  const projectDepsP = ProjectDependencies.collect(
     options,
     elmJsonData.project,
     reviewElmJson.dependencies.direct,
     elmVersion
   );
-  const linksToRuleDocs = ProjectDependencies.collectRuleLinks(
-    reviewElmJson.dependencies.direct,
-    elmVersion
-  );
+
+  const [projectDeps, suppressedErrors, linksToRuleDocs] = await Promise.all([
+    projectDepsP,
+    suppressedErrorsP,
+    linksToRuleDocsP
+  ])
 
   await sendProjectContent(
     options,
@@ -144,8 +151,8 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
     readme,
     elmFiles,
     projectDeps,
-    await suppressedErrors,
-    await linksToRuleDocs
+    suppressedErrors,
+    linksToRuleDocs
   );
 
   return {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,6 +8,7 @@ const AppWrapper = require('./app-wrapper');
 const ErrorMessage = require('./error-message');
 const {getProjectFiles} = require('./elm-files');
 const SuppressedErrors = require('./suppressed-errors');
+const ReviewDependencies = require('./review-dependencies');
 const ProjectDependencies = require('./project-dependencies');
 const {runReview, startReview, requestReview} = require('./run-review');
 
@@ -120,7 +121,7 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
 
   const suppressedErrorsP = SuppressedErrors.read(options);
 
-  const linksToRuleDocsP = ProjectDependencies.collectRuleLinks(
+  const linksToRuleDocsP = ReviewDependencies.collectRuleLinks(
     reviewElmJson.dependencies.direct,
     elmVersion
   );

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -142,7 +142,7 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
     projectDepsP,
     suppressedErrorsP,
     linksToRuleDocsP
-  ])
+  ]);
 
   await sendProjectContent(
     options,


### PR DESCRIPTION
These things are pretty different, and don't really need to be shared.

### Context

Project dependencies are used for the analysis of the project


Rule links are information fetched to create links on the rule name in the terminal that send you to the rule's documentation, like in the screenshot below:

![image](https://user-images.githubusercontent.com/3869412/232221222-d0ddc005-567b-4cd1-8b9f-71797be788d0.png)

### Effects

1) Separating the fetching of these will make it easier in future work to only fetch the updated project dependencies when they have changed, without fetching the rule links.

2) The code should be slightly easier to read, as I've split things up into multiple self-contained modules.

3) Startup performance might be a bit improved because of a few changes:
- Since these two steps are now separated, we can start the fetching of rule links earlier, before some necessary steps for fetching the project deps are completed
- We now re-use the same promise for fetching the same dependencies (should be rare though!)
- We don't fetch the `elm/*` dependencies for rule links, as it's quite unlikely that they will contain `elm-review` rules in the foreseeable future.