### PR TITLE
Collect dependencies when elm.json gets autofixed

### DIFF
--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -10,6 +10,7 @@ const ErrorMessage = require('./error-message');
 const promisifyPort = require('./promisify-port');
 const StyledMessage = require('./styled-message');
 const {startReview} = require('./run-review');
+const ProjectDependencies = require('./project-dependencies');
 
 const fsWriteFile = util.promisify(fs.writeFile);
 
@@ -79,8 +80,10 @@ function askConfirmationToFixWithOptions(options, app, elmVersion) {
     }
 
     if (accepted) {
+      let modifiedElmJson;
       const basePath = options.projectToReview();
-      const formattedFiles = await Promise.all(
+
+      const formattedFiles = Promise.all(
         filesToFix.map((file) => {
           const filePath = path.resolve(basePath, file.path);
           if (filePath.endsWith('.elm')) {
@@ -88,13 +91,29 @@ function askConfirmationToFixWithOptions(options, app, elmVersion) {
             return formatFileContent(options, file, filePath);
           }
 
+          if (file.path === 'elm.json') {
+            modifiedElmJson = file;
+          }
+
           return fsWriteFile(filePath, file.source).then(() => file);
         })
       );
 
+      let dependencies;
+      if (modifiedElmJson) {
+        // TODO Check if source-directories have changed, and if so, load/unload the necessary files.
+        // TODO Check if dependencies have changed before we do this
+        dependencies = await ProjectDependencies.collect(
+          options,
+          JSON.parse(modifiedElmJson.source),
+          elmVersion
+        );
+      }
+
       app.ports.userConfirmedFix.send({
         answer: true,
-        files: formattedFiles
+        files: await formattedFiles,
+        dependencies
       });
 
       AppState.fixWasAccepted();

--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -110,13 +110,12 @@ function askConfirmationToFixWithOptions(options, app, elmVersion) {
         );
       }
 
+      AppState.fixWasAccepted();
       app.ports.userConfirmedFix.send({
         answer: true,
         files: await formattedFiles,
         dependencies
       });
-
-      AppState.fixWasAccepted();
     } else {
       AppState.fixWasRefused();
       app.ports.userConfirmedFix.send({

--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const util = require('util');
 const fs = require('fs-extra');
 const chalk = require('chalk');
 const prompts = require('prompts');
@@ -9,6 +10,8 @@ const ErrorMessage = require('./error-message');
 const promisifyPort = require('./promisify-port');
 const StyledMessage = require('./styled-message');
 const {startReview} = require('./run-review');
+
+const fsWriteFile = util.promisify(fs.writeFile);
 
 module.exports = {
   subscribe: (options, app, elmVersion) => {
@@ -77,15 +80,17 @@ function askConfirmationToFixWithOptions(options, app, elmVersion) {
 
     if (accepted) {
       const basePath = options.projectToReview();
-      const formattedFiles = filesToFix.map((file) => {
-        const filePath = path.resolve(basePath, file.path);
-        if (filePath.endsWith('.elm')) {
-          return formatFileContent(options, file, filePath);
-        }
+      const formattedFiles = await Promise.all(
+        filesToFix.map((file) => {
+          const filePath = path.resolve(basePath, file.path);
+          if (filePath.endsWith('.elm')) {
+            // TODO Make this async
+            return formatFileContent(options, file, filePath);
+          }
 
-        fs.writeFileSync(filePath, file.source);
-        return file;
-      });
+          return fsWriteFile(filePath, file.source).then(() => file);
+        })
+      );
 
       app.ports.userConfirmedFix.send({
         answer: true,

--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -11,15 +11,15 @@ const StyledMessage = require('./styled-message');
 const {startReview} = require('./run-review');
 
 module.exports = {
-  subscribe: (options, app) => {
+  subscribe: (options, app, elmVersion) => {
     AppState.subscribe(
       app.ports.askConfirmationToFix,
-      askConfirmationToFixWithOptions(options, app)
+      askConfirmationToFixWithOptions(options, app, elmVersion)
     );
   }
 };
 
-function askConfirmationToFixWithOptions(options, app) {
+function askConfirmationToFixWithOptions(options, app, elmVersion) {
   return async (data) => {
     if (!options.fixAllWithoutPrompt) {
       StyledMessage.clearAndLog(

--- a/lib/project-dependencies.js
+++ b/lib/project-dependencies.js
@@ -4,7 +4,7 @@ module.exports = {
   collect
 };
 
-async function collect(options, elmJson, reviewDirectDependencies, elmVersion) {
+async function collect(options, elmJson, elmVersion) {
   const dependenciesEntries =
     elmJson.type === 'application'
       ? {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -136,7 +136,6 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
   const projectDepsP = ProjectDependencies.collect(
     options,
     elmJsonData.project,
-    reviewElmJson.dependencies.direct,
     elmVersion
   );
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -98,7 +98,7 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
   });
 
   ModuleCache.subscribe(options, app);
-  Autofix.subscribe(options, app);
+  Autofix.subscribe(options, app, reviewElmJson['elm-version']);
   if (options.watch) {
     AppState.subscribe(app.ports.reviewReport, (result) => {
       return Promise.all([

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -71,6 +71,8 @@ function watchFiles(
             clearConsole();
           }
 
+          // TODO Detect what has changed and only re-load the necessary parts.
+          // We do some of this work in `autofix.js` already.
           Debug.log('Your `elm.json` has changed. Restarting elm-review.');
         }
 

--- a/template/src/Elm/Review/Main.elm
+++ b/template/src/Elm/Review/Main.elm
@@ -843,6 +843,7 @@ refuseError error model =
 type Confirmation
     = Accepted
         { rawFiles : List { path : String, source : String, ast : Maybe Elm.Syntax.File.File }
+        , dependencies : Maybe (List Dependency)
         }
     | Refused
 
@@ -853,8 +854,9 @@ confirmationDecoder ignoreProblematicDependencies =
         |> Decode.andThen
             (\accepted ->
                 if accepted then
-                    Decode.map (\rawFiles -> Accepted { rawFiles = rawFiles })
+                    Decode.map2 (\rawFiles dependencies -> Accepted { rawFiles = rawFiles, dependencies = dependencies })
                         (Decode.field "files" (Decode.list Elm.Review.File.decode))
+                        (Decode.field "dependencies" (dependenciesDecoder ignoreProblematicDependencies) |> Decode.maybe)
 
                 else
                     Decode.succeed Refused

--- a/template/src/Elm/Review/Main.elm
+++ b/template/src/Elm/Review/Main.elm
@@ -672,7 +672,7 @@ If I am mistaken about the nature of problem, please open a bug report at https:
             )
 
         UserConfirmedFix confirmation ->
-            case Decode.decodeValue confirmationDecoder confirmation of
+            case Decode.decodeValue (confirmationDecoder model.ignoreProblematicDependencies) confirmation of
                 Ok (Accepted rawFiles) ->
                     let
                         previousProject : Project
@@ -845,8 +845,8 @@ type Confirmation
     | Refused
 
 
-confirmationDecoder : Decode.Decoder Confirmation
-confirmationDecoder =
+confirmationDecoder : Bool -> Decode.Decoder Confirmation
+confirmationDecoder ignoreProblematicDependencies =
     Decode.field "answer" Decode.bool
         |> Decode.andThen
             (\accepted ->

--- a/template/src/Elm/Review/Main.elm
+++ b/template/src/Elm/Review/Main.elm
@@ -673,7 +673,7 @@ If I am mistaken about the nature of problem, please open a bug report at https:
 
         UserConfirmedFix confirmation ->
             case Decode.decodeValue (confirmationDecoder model.ignoreProblematicDependencies) confirmation of
-                Ok (Accepted rawFiles) ->
+                Ok (Accepted { rawFiles }) ->
                     let
                         previousProject : Project
                         previousProject =
@@ -841,7 +841,9 @@ refuseError error model =
 
 
 type Confirmation
-    = Accepted (List { path : String, source : String, ast : Maybe Elm.Syntax.File.File })
+    = Accepted
+        { rawFiles : List { path : String, source : String, ast : Maybe Elm.Syntax.File.File }
+        }
     | Refused
 
 
@@ -851,8 +853,8 @@ confirmationDecoder ignoreProblematicDependencies =
         |> Decode.andThen
             (\accepted ->
                 if accepted then
-                    Decode.field "files" (Decode.list Elm.Review.File.decode)
-                        |> Decode.map Accepted
+                    Decode.map (\rawFiles -> Accepted { rawFiles = rawFiles })
+                        (Decode.field "files" (Decode.list Elm.Review.File.decode))
 
                 else
                     Decode.succeed Refused


### PR DESCRIPTION
When `elm.json` gets autofixed because of rules like `NoUnused.Dependencies`, the list of dependencies in the project will be refetched.

This should remove potential false positives where a rule takes the list of dependencies as a source of truth instead of the dependencies listed in `elm.json`.

Some further work can be done later to avoid doing this when the dependencies fields have not changed. And similar work should be done for when the source-directories change. But so far the only known rule that autofixes `elm.json` is `NoUnused.Dependencies`, which does not trigger false positives even if the dependencies were not getting updated.