### PR TITLE
Require jfmengels/elm-review 2.13.0 or higher

### DIFF
--- a/lib/min-version.js
+++ b/lib/min-version.js
@@ -2,7 +2,7 @@ const path = require('path');
 const chalk = require('chalk');
 const ErrorMessage = require('./error-message');
 
-const minimalVersion = {major: 2, minor: 11};
+const minimalVersion = {major: 2, minor: 13};
 /* eslint-disable prettier/prettier */
 const supportedRange = `${minimalVersion.major}.${minimalVersion.minor}.0 <= v < ${minimalVersion.major + 1}.0.0`
 /* eslint-enable prettier/prettier */

--- a/new-package/review-config-templates/2.3.0/elm.json
+++ b/new-package/review-config-templates/2.3.0/elm.json
@@ -9,13 +9,13 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.12.0",
+            "jfmengels/elm-review": "2.13.0",
             "jfmengels/elm-review-code-style": "1.1.3",
-            "jfmengels/elm-review-cognitive-complexity": "1.0.2",
+            "jfmengels/elm-review-cognitive-complexity": "1.0.3",
             "jfmengels/elm-review-common": "1.3.2",
             "jfmengels/elm-review-debug": "1.0.8",
             "jfmengels/elm-review-documentation": "2.0.3",
-            "jfmengels/elm-review-simplify": "2.0.24",
+            "jfmengels/elm-review-simplify": "2.0.28",
             "jfmengels/elm-review-unused": "1.1.29",
             "sparksp/elm-review-forbidden-words": "1.0.1",
             "stil4m/elm-syntax": "7.2.9"
@@ -29,7 +29,7 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.1.0",
+            "elm-explorations/test": "2.1.1",
             "miniBill/elm-unicode": "1.0.3",
             "pzp1997/assoc-list": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
@@ -38,7 +38,7 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "2.1.0"
+            "elm-explorations/test": "2.1.1"
         },
         "indirect": {}
     }

--- a/template/elm.json
+++ b/template/elm.json
@@ -11,7 +11,7 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
+            "jfmengels/elm-review": "2.13.0",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -22,7 +22,7 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.1.0",
+            "elm-explorations/test": "2.1.1",
             "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
@@ -30,7 +30,7 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "2.1.0"
+            "elm-explorations/test": "2.1.1"
         },
         "indirect": {}
     }

--- a/test/config-configuration-error/elm.json
+++ b/test/config-configuration-error/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/config-empty/elm.json
+++ b/test/config-empty/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/config-error-debug/elm.json
+++ b/test/config-error-debug/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/config-error-unknown-module/elm.json
+++ b/test/config-error-unknown-module/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/config-syntax-error/elm.json
+++ b/test/config-syntax-error/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/config-that-triggers-no-errors/elm.json
+++ b/test/config-that-triggers-no-errors/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/config-that-triggers-no-errors/src/ReviewConfig.elm
+++ b/test/config-that-triggers-no-errors/src/ReviewConfig.elm
@@ -11,11 +11,11 @@ when inside the directory containing this file.
 
 -}
 
-import NoUnused.Exports
+import NoUnused.Patterns
 import Review.Rule exposing (Rule)
 
 
 config : List Rule
 config =
-    [ NoUnused.Exports.rule
+    [ NoUnused.Patterns.rule
     ]

--- a/test/config-without-elm-review/elm.json
+++ b/test/config-without-elm-review/elm.json
@@ -9,7 +9,7 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -20,9 +20,9 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "jfmengels/elm-review": "2.11.0",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "jfmengels/elm-review": "2.13.0",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/project-using-es2015-module/review/elm.json
+++ b/test/project-using-es2015-module/review/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/project-with-errors/review/elm.json
+++ b/test/project-with-errors/review/elm.json
@@ -9,7 +9,7 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
+            "jfmengels/elm-review": "2.13.0",
             "jfmengels/elm-review-unused": "1.1.8",
             "stil4m/elm-syntax": "7.2.9"
         },

--- a/test/project-with-suppressed-errors/review/elm.json
+++ b/test/project-with-suppressed-errors/review/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/project-with-suppressed-errors2/review/elm.json
+++ b/test/project-with-suppressed-errors2/review/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/project-with-unsupported-suppression-version/review/elm.json
+++ b/test/project-with-unsupported-suppression-version/review/elm.json
@@ -9,8 +9,8 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
-            "jfmengels/elm-review-unused": "1.1.8",
+            "jfmengels/elm-review": "2.13.0",
+            "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {
@@ -21,8 +21,8 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "elm-community/list-extra": "8.7.0",
-            "elm-explorations/test": "2.0.1",
-            "miniBill/elm-unicode": "1.0.2",
+            "elm-explorations/test": "2.1.1",
+            "miniBill/elm-unicode": "1.0.3",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/test/run-snapshots/elm-review-something-for-new-rule/elm.json
+++ b/test/run-snapshots/elm-review-something-for-new-rule/elm.json
@@ -12,7 +12,7 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "jfmengels/elm-review": "2.11.0 <= v < 3.0.0",
+        "jfmengels/elm-review": "2.13.0 <= v < 3.0.0",
         "stil4m/elm-syntax": "7.2.9 <= v < 8.0.0"
     },
     "test-dependencies": {

--- a/test/run-snapshots/elm-review-something-for-new-rule/preview/elm.json
+++ b/test/run-snapshots/elm-review-something-for-new-rule/preview/elm.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",
-            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review": "2.13.0",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {

--- a/test/run-snapshots/elm-review-something-for-new-rule/review/elm.json
+++ b/test/run-snapshots/elm-review-something-for-new-rule/review/elm.json
@@ -9,7 +9,7 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review": "2.13.0",
             "jfmengels/elm-review-code-style": "1.1.3",
             "jfmengels/elm-review-cognitive-complexity": "1.0.3",
             "jfmengels/elm-review-common": "1.3.2",

--- a/test/run-snapshots/elm-review-something/elm.json
+++ b/test/run-snapshots/elm-review-something/elm.json
@@ -10,7 +10,7 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "jfmengels/elm-review": "2.11.0 <= v < 3.0.0",
+        "jfmengels/elm-review": "2.13.0 <= v < 3.0.0",
         "stil4m/elm-syntax": "7.2.9 <= v < 8.0.0"
     },
     "test-dependencies": {

--- a/test/run-snapshots/elm-review-something/preview/elm.json
+++ b/test/run-snapshots/elm-review-something/preview/elm.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",
-            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review": "2.13.0",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {

--- a/test/run-snapshots/elm-review-something/review/elm.json
+++ b/test/run-snapshots/elm-review-something/review/elm.json
@@ -9,7 +9,7 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review": "2.13.0",
             "jfmengels/elm-review-code-style": "1.1.3",
             "jfmengels/elm-review-cognitive-complexity": "1.0.3",
             "jfmengels/elm-review-common": "1.3.2",

--- a/test/run-snapshots/init-project/review/elm.json
+++ b/test/run-snapshots/init-project/review/elm.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",
-            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review": "2.13.0",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {

--- a/test/run-snapshots/init-template-project/review/elm.json
+++ b/test/run-snapshots/init-template-project/review/elm.json
@@ -8,7 +8,7 @@
         "direct": {
             "elm/core": "1.0.5",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review": "2.13.0",
             "jfmengels/elm-review-unused": "1.1.29",
             "stil4m/elm-syntax": "7.2.9"
         },

--- a/test/run-snapshots/project to fix/review/elm.json
+++ b/test/run-snapshots/project to fix/review/elm.json
@@ -9,7 +9,7 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.11.0",
+            "jfmengels/elm-review": "2.13.0",
             "jfmengels/elm-review-unused": "1.1.8",
             "stil4m/elm-syntax": "7.2.9"
         },

--- a/test/run-snapshots/remote-with-outdated-elm-review-version-json.txt
+++ b/test/run-snapshots/remote-with-outdated-elm-review-version-json.txt
@@ -3,6 +3,6 @@
   "title": "UNSUPPORTED ELM-REVIEW VERSION",
   "path": "<local-path>/test/project-with-errors/review/elm.json",
   "message": [
-    "The template uses an unsupported version of the jfmengels/elm-review Elm package. It is using version 1.0.0, but I need it to be 2.11.0 <= v < 3.0.0.\n\nPlease inform the template author and kindly ask them to update their configuration, or make a pull request to help them out."
+    "The template uses an unsupported version of the jfmengels/elm-review Elm package. It is using version 1.0.0, but I need it to be 2.13.0 <= v < 3.0.0.\n\nPlease inform the template author and kindly ask them to update their configuration, or make a pull request to help them out."
   ]
 }

--- a/test/run-snapshots/remote-with-outdated-elm-review-version-ndjson.txt
+++ b/test/run-snapshots/remote-with-outdated-elm-review-version-ndjson.txt
@@ -3,6 +3,6 @@
   "title": "UNSUPPORTED ELM-REVIEW VERSION",
   "path": "<local-path>/test/project-with-errors/review/elm.json",
   "message": [
-    "The template uses an unsupported version of the jfmengels/elm-review Elm package. It is using version 1.0.0, but I need it to be 2.11.0 <= v < 3.0.0.\n\nPlease inform the template author and kindly ask them to update their configuration, or make a pull request to help them out."
+    "The template uses an unsupported version of the jfmengels/elm-review Elm package. It is using version 1.0.0, but I need it to be 2.13.0 <= v < 3.0.0.\n\nPlease inform the template author and kindly ask them to update their configuration, or make a pull request to help them out."
   ]
 }

--- a/test/run-snapshots/remote-with-outdated-elm-review-version.txt
+++ b/test/run-snapshots/remote-with-outdated-elm-review-version.txt
@@ -2,7 +2,7 @@
 ✖ Fetching template information
 -- UNSUPPORTED ELM-REVIEW VERSION ----------------------------------------------
 
-The template uses an unsupported version of the jfmengels/elm-review Elm package. It is using version 1.0.0, but I need it to be 2.11.0 <= v < 3.0.0.
+The template uses an unsupported version of the jfmengels/elm-review Elm package. It is using version 1.0.0, but I need it to be 2.13.0 <= v < 3.0.0.
 
 Please inform the template author and kindly ask them to update their configuration, or make a pull request to help them out.
 

--- a/test/run-snapshots/suppressed-errors-introducing-new-errors-json.txt
+++ b/test/run-snapshots/suppressed-errors-introducing-new-errors-json.txt
@@ -7,7 +7,7 @@
         {
           "rule": "NoUnused.Variables",
           "message": "Imported variable `h1` is not used",
-          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables",
+          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables",
           "details": [
             "You should either use this value somewhere, or remove it at the location I pointed at."
           ],
@@ -48,7 +48,7 @@
             {
               "string": "NoUnused.Variables",
               "color": "#FF0000",
-              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables"
+              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables"
             },
             ": Imported variable `h1` is not used\n\n10|         , -- h1 is unused\n11|           h1\n              ",
             {
@@ -63,7 +63,7 @@
         {
           "rule": "NoUnused.Variables",
           "message": "Imported variable `span` is not used",
-          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables",
+          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables",
           "details": [
             "You should either use this value somewhere, or remove it at the location I pointed at."
           ],
@@ -104,7 +104,7 @@
             {
               "string": "NoUnused.Variables",
               "color": "#FF0000",
-              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables"
+              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables"
             },
             ": Imported variable `span` is not used\n\n12|         , -- span is unused\n13|           span\n              ",
             {
@@ -124,7 +124,7 @@
         {
           "rule": "NoUnused.Variables",
           "message": "Top-level variable `b` is not used",
-          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables",
+          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables",
           "details": [
             "You should either use this value somewhere, or remove it at the location I pointed at."
           ],
@@ -165,7 +165,7 @@
             {
               "string": "NoUnused.Variables",
               "color": "#FF0000",
-              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables"
+              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables"
             },
             ": Top-level variable `b` is not used\n\n8| b =\n   ",
             {
@@ -180,7 +180,7 @@
         {
           "rule": "NoUnused.Variables",
           "message": "Top-level variable `c` is not used",
-          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables",
+          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables",
           "details": [
             "You should either use this value somewhere, or remove it at the location I pointed at."
           ],
@@ -221,7 +221,7 @@
             {
               "string": "NoUnused.Variables",
               "color": "#FF0000",
-              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables"
+              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables"
             },
             ": Top-level variable `c` is not used\n\n12| c =\n    ",
             {
@@ -241,7 +241,7 @@
         {
           "rule": "NoUnused.Dependencies",
           "message": "Unused dependency `elm/time`",
-          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Dependencies",
+          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Dependencies",
           "details": [
             "To remove it, I recommend running the following command:",
             "    elm-json uninstall elm/time"
@@ -256,15 +256,34 @@
               "column": 22
             }
           },
+          "fix": [
+            {
+              "range": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 100000000,
+                  "column": 1
+                }
+              },
+              "string": "{\n    \"type\": \"application\",\n    \"source-directories\": [\n        \"src\"\n    ],\n    \"elm-version\": \"0.19.1\",\n    \"dependencies\": {\n        \"direct\": {\n            \"elm/browser\": \"1.0.2\",\n            \"elm/core\": \"1.0.5\",\n            \"elm/html\": \"1.0.0\"\n        },\n        \"indirect\": {\n            \"elm/json\": \"1.1.3\",\n            \"elm/time\": \"1.0.0\",\n            \"elm/url\": \"1.0.0\",\n            \"elm/virtual-dom\": \"1.0.2\"\n        }\n    },\n    \"test-dependencies\": {\n        \"direct\": {},\n        \"indirect\": {}\n    }\n}\n"
+            }
+          ],
           "formatted": [
             {
               "string": "(unsuppressed) ",
               "color": "#FFA500"
             },
             {
+              "string": "(fix) ",
+              "color": "#33BBC8"
+            },
+            {
               "string": "NoUnused.Dependencies",
               "color": "#FF0000",
-              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Dependencies"
+              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Dependencies"
             },
             ": Unused dependency `elm/time`\n\n11|             \"elm/html\": \"1.0.0\",\n12|             \"elm/time\": \"1.0.0\"\n                 ",
             {

--- a/test/run-snapshots/suppressed-errors-pass-json.txt
+++ b/test/run-snapshots/suppressed-errors-pass-json.txt
@@ -7,7 +7,7 @@
         {
           "rule": "NoUnused.Variables",
           "message": "Imported variable `h1` is not used",
-          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables",
+          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables",
           "details": [
             "You should either use this value somewhere, or remove it at the location I pointed at."
           ],
@@ -48,7 +48,7 @@
             {
               "string": "NoUnused.Variables",
               "color": "#FF0000",
-              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables"
+              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables"
             },
             ": Imported variable `h1` is not used\n\n10|         , -- h1 is unused\n11|           h1\n              ",
             {
@@ -63,7 +63,7 @@
         {
           "rule": "NoUnused.Variables",
           "message": "Imported variable `span` is not used",
-          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables",
+          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables",
           "details": [
             "You should either use this value somewhere, or remove it at the location I pointed at."
           ],
@@ -104,7 +104,7 @@
             {
               "string": "NoUnused.Variables",
               "color": "#FF0000",
-              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables"
+              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables"
             },
             ": Imported variable `span` is not used\n\n12|         , -- span is unused\n13|           span\n              ",
             {
@@ -124,7 +124,7 @@
         {
           "rule": "NoUnused.Variables",
           "message": "Top-level variable `b` is not used",
-          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables",
+          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables",
           "details": [
             "You should either use this value somewhere, or remove it at the location I pointed at."
           ],
@@ -165,7 +165,7 @@
             {
               "string": "NoUnused.Variables",
               "color": "#FF0000",
-              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Variables"
+              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Variables"
             },
             ": Top-level variable `b` is not used\n\n8| b =\n   ",
             {
@@ -185,7 +185,7 @@
         {
           "rule": "NoUnused.Dependencies",
           "message": "Unused dependency `elm/time`",
-          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Dependencies",
+          "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Dependencies",
           "details": [
             "To remove it, I recommend running the following command:",
             "    elm-json uninstall elm/time"
@@ -200,15 +200,34 @@
               "column": 22
             }
           },
+          "fix": [
+            {
+              "range": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 100000000,
+                  "column": 1
+                }
+              },
+              "string": "{\n    \"type\": \"application\",\n    \"source-directories\": [\n        \"src\"\n    ],\n    \"elm-version\": \"0.19.1\",\n    \"dependencies\": {\n        \"direct\": {\n            \"elm/browser\": \"1.0.2\",\n            \"elm/core\": \"1.0.5\",\n            \"elm/html\": \"1.0.0\"\n        },\n        \"indirect\": {\n            \"elm/json\": \"1.1.3\",\n            \"elm/time\": \"1.0.0\",\n            \"elm/url\": \"1.0.0\",\n            \"elm/virtual-dom\": \"1.0.2\"\n        }\n    },\n    \"test-dependencies\": {\n        \"direct\": {},\n        \"indirect\": {}\n    }\n}\n"
+            }
+          ],
           "formatted": [
             {
               "string": "(unsuppressed) ",
               "color": "#FFA500"
             },
             {
+              "string": "(fix) ",
+              "color": "#33BBC8"
+            },
+            {
               "string": "NoUnused.Dependencies",
               "color": "#FF0000",
-              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.8/NoUnused-Dependencies"
+              "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-unused/1.1.29/NoUnused-Dependencies"
             },
             ": Unused dependency `elm/time`\n\n11|             \"elm/html\": \"1.0.0\",\n12|             \"elm/time\": \"1.0.0\"\n                 ",
             {

--- a/test/snapshots/review/config-es2015-modules.txt
+++ b/test/snapshots/review/config-es2015-modules.txt
@@ -12,8 +12,8 @@ pointed at.
 
 ────────────────────────────────────────────────────────────── src/Main.elm:28:7
 
-NoUnused.CustomTypeConstructors: Type constructor `UnusedCustomType` is not
-used.
+(fix) NoUnused.CustomTypeConstructors: Type constructor `UnusedCustomType` is
+not used.
 
 27|     | Decrement
 28|     | UnusedCustomType

--- a/test/snapshots/review/outdated-version.txt
+++ b/test/snapshots/review/outdated-version.txt
@@ -1,6 +1,6 @@
 -- UNSUPPORTED ELM-REVIEW VERSION ----------------------------------------------
 
-You are using an unsupported version of the jfmengels/elm-review Elm package. You are using version 1.0.0, but I need it to be 2.11.0 <= v < 3.0.0.
+You are using an unsupported version of the jfmengels/elm-review Elm package. You are using version 1.0.0, but I need it to be 2.13.0 <= v < 3.0.0.
 
 Please upgrade your version by running
 npx elm-json install jfmengels/elm-review@2 inside

--- a/test/snapshots/suppress/suppressed-errors-unsuppress-rules.txt
+++ b/test/snapshots/suppress/suppressed-errors-unsuppress-rules.txt
@@ -1,6 +1,6 @@
 -- ELM-REVIEW ERROR --------------------------------------------- elm.json:12:14
 
-(unsuppressed) NoUnused.Dependencies: Unused dependency `elm/time`
+(unsuppressed) (fix) NoUnused.Dependencies: Unused dependency `elm/time`
 
 11|             "elm/html": "1.0.0",
 12|             "elm/time": "1.0.0"
@@ -10,5 +10,7 @@
 To remove it, I recommend running the following command:
 
     elm-json uninstall elm/time
+
+Errors marked with (fix) can be fixed automatically using `elm-review --fix`.
 
 I found 1 error in 1 file.

--- a/test/snapshots/suppress/suppressed-errors-unsuppress.txt
+++ b/test/snapshots/suppress/suppressed-errors-unsuppress.txt
@@ -1,6 +1,6 @@
 -- ELM-REVIEW ERROR --------------------------------------------- elm.json:12:14
 
-(unsuppressed) NoUnused.Dependencies: Unused dependency `elm/time`
+(unsuppressed) (fix) NoUnused.Dependencies: Unused dependency `elm/time`
 
 11|             "elm/html": "1.0.0",
 12|             "elm/time": "1.0.0"


### PR DESCRIPTION
This will be necessary in future PRs, where we will use [`Review.Rule.errorFixFailure`](https://package.elm-lang.org/packages/jfmengels/elm-review/latest/Review-Rule#errorFixFailure) that was introduced in v2.13.0, and so that we can stop trying to apply fixes inside the CLI.