### PR TITLE
Improve the 'Unsupported elm-review version' message

### DIFF
--- a/lib/min-version.js
+++ b/lib/min-version.js
@@ -54,25 +54,21 @@ Please inform the template author and kindly ask them to update their configurat
     );
   }
 
-  const upgradeCommand =
-    major === '2' && Number.parseInt(minor, 10) < 10
-      ? // Due to complicated upgrade to v2.10.0 due to dependency on elm-explorations/test v1
-        'npx elm-json upgrade --unsafe'
-      : `npx elm-json install jfmengels/elm-review@${minimalVersion.major}`;
-
   throw new ErrorMessage.CustomError(
     /* eslint-disable prettier/prettier */
 'UNSUPPORTED ELM-REVIEW VERSION',
 `You are using an unsupported version of the ${chalk.greenBright('jfmengels/elm-review')} Elm package.
 You are using version ${chalk.red(version)}, but I need it to be ${chalk.greenBright(supportedRange)}.
 
-Please upgrade your version by running
-
-${chalk.magenta(upgradeCommand)}
-
-  inside of
-
-${chalk.yellow(path.dirname(elmJsonPath))}`
+Please upgrade your version by running the following commands:
+${chalk.magenta(`
+cd ${path.dirname(elmJsonPath)}
+npx elm-json install jfmengels/elm-review@${minimalVersion.major}
+`)}
+If that doesn't work, try out:
+${chalk.magenta(`
+cd ${path.dirname(elmJsonPath)}
+npx elm-json upgrade --unsafe`)}`
       /* eslint-enable prettier/prettier */
   );
 }

--- a/lib/min-version.js
+++ b/lib/min-version.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const chalk = require('chalk');
+const PathHelpers = require('./path-helpers');
 const ErrorMessage = require('./error-message');
 
 const minimalVersion = {major: 2, minor: 13};
@@ -53,6 +54,7 @@ Please inform the template author and kindly ask them to update their configurat
         /* eslint-enable prettier/prettier */
     );
   }
+  const dirPath = PathHelpers.format(path.dirname(elmJsonPath));
 
   throw new ErrorMessage.CustomError(
     /* eslint-disable prettier/prettier */
@@ -62,12 +64,12 @@ You are using version ${chalk.red(version)}, but I need it to be ${chalk.greenBr
 
 Please upgrade your version by running the following commands:
 ${chalk.magenta(`
-cd ${path.dirname(elmJsonPath)}
+cd ${dirPath}
 npx elm-json install jfmengels/elm-review@${minimalVersion.major}
 `)}
 If that doesn't work, try out:
 ${chalk.magenta(`
-cd ${path.dirname(elmJsonPath)}
+cd ${dirPath}
 npx elm-json upgrade --unsafe`)}`
       /* eslint-enable prettier/prettier */
   );

--- a/lib/min-version.js
+++ b/lib/min-version.js
@@ -63,11 +63,16 @@ Please inform the template author and kindly ask them to update their configurat
   throw new ErrorMessage.CustomError(
     /* eslint-disable prettier/prettier */
 'UNSUPPORTED ELM-REVIEW VERSION',
-`You are using an unsupported version of the ${chalk.greenBright('jfmengels/elm-review')} Elm package. You are using version ${version}, but I need it to be ${supportedRange}.
+`You are using an unsupported version of the ${chalk.greenBright('jfmengels/elm-review')} Elm package.
+You are using version ${chalk.red(version)}, but I need it to be ${chalk.greenBright(supportedRange)}.
 
 Please upgrade your version by running
-${chalk.magenta(upgradeCommand)} inside
-of ${chalk.yellow(path.dirname(elmJsonPath))}.`
+
+${chalk.magenta(upgradeCommand)}
+
+  inside of
+
+${chalk.yellow(path.dirname(elmJsonPath))}`
       /* eslint-enable prettier/prettier */
   );
 }

--- a/lib/path-helpers.js
+++ b/lib/path-helpers.js
@@ -1,0 +1,18 @@
+function makePathOsAgnostic(path_) {
+  return path_.replace(/.:/, '').replace(/\\/g, '/');
+}
+
+module.exports = {
+  format
+};
+
+
+/**
+ * Format a path so that you can `cd` it.
+ * @param {string} str
+ * @returns {string}
+ */
+function format(str) {
+  const regex = /(['\s"])/g;
+  return str.replace(regex, '\\$1');
+}

--- a/test/path-helpers.test.js
+++ b/test/path-helpers.test.js
@@ -1,0 +1,25 @@
+const PathHelpers = require('../lib/path-helpers');
+
+test('should leave the path untouched if it does not contain odd characters', () => {
+  const input = 'some-folder123';
+  const output = PathHelpers.format(input);
+  expect(output).toEqual(input);
+});
+
+test('should escape single quotes', () => {
+  const input = "Don't-do-that";
+  const output = PathHelpers.format(input);
+  expect(output).toEqual('Don\\\'t-do-that');
+});
+
+test('should escape double quotes', () => {
+  const input = 'Don\"t-do-that';
+  const output = PathHelpers.format(input);
+  expect(output).toEqual('Don\\\"t-do-that');
+});
+
+test('should escape spaces', () => {
+  const input = "some path";
+  const output = PathHelpers.format(input);
+  expect(output).toEqual('some\\ path');
+});

--- a/test/snapshots/review/outdated-version.txt
+++ b/test/snapshots/review/outdated-version.txt
@@ -1,8 +1,13 @@
 -- UNSUPPORTED ELM-REVIEW VERSION ----------------------------------------------
 
-You are using an unsupported version of the jfmengels/elm-review Elm package. You are using version 1.0.0, but I need it to be 2.13.0 <= v < 3.0.0.
+You are using an unsupported version of the jfmengels/elm-review Elm package.
+You are using version 1.0.0, but I need it to be 2.13.0 <= v < 3.0.0.
 
 Please upgrade your version by running
-npx elm-json install jfmengels/elm-review@2 inside
-of <local-path>/test/config-for-outdated-elm-review-version.
+
+npx elm-json install jfmengels/elm-review@2
+
+  inside of
+
+<local-path>/test/config-for-outdated-elm-review-version
 

--- a/test/snapshots/review/outdated-version.txt
+++ b/test/snapshots/review/outdated-version.txt
@@ -3,11 +3,13 @@
 You are using an unsupported version of the jfmengels/elm-review Elm package.
 You are using version 1.0.0, but I need it to be 2.13.0 <= v < 3.0.0.
 
-Please upgrade your version by running
+Please upgrade your version by running the following commands:
 
+cd <local-path>/test/config-for-outdated-elm-review-version
 npx elm-json install jfmengels/elm-review@2
 
-  inside of
+If that doesn't work, try out:
 
-<local-path>/test/config-for-outdated-elm-review-version
+cd <local-path>/test/config-for-outdated-elm-review-version
+npx elm-json upgrade --unsafe
 


### PR DESCRIPTION
## Before

```
-- UNSUPPORTED ELM-REVIEW VERSION ----------------------------------------------

You are using an unsupported version of the jfmengels/elm-review Elm package. You are using version 2.12.2, but I need it to be 2.13.0 <= v < 3.0.0.

Please upgrade your version by running
npx elm-json install jfmengels/elm-review@2 inside
of /Users/jengels/dev/elm-spa-example/review.
```

## After

```
-- UNSUPPORTED ELM-REVIEW VERSION ----------------------------------------------

You are using an unsupported version of the jfmengels/elm-review Elm package.
You are using version 2.12.2, but I need it to be 2.13.0 <= v < 3.0.0.

Please upgrade your version by running the following commands:

cd /home/jeroen/dev/elm-spa-example/review
npx elm-json install jfmengels/elm-review@2

If that doesn't work, try out:

cd /home/jeroen/dev/elm-spa-example/review
npx elm-json upgrade --unsafe
```

Sceenshot:
![image](https://user-images.githubusercontent.com/3869412/232614896-f86feb2f-8cc5-4d31-8e4a-83c351f22772.png)

