### PR TITLE
Re-use existing elm.json for the compilation

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -320,6 +320,7 @@ async function createTemplateProject(
     reviewElmJsonPath
   );
   await FS.mkdirp(path.dirname(elmJsonPath));
+  const previousElmJson = await FS.readFile(elmJsonPath).catch(() => null);
   const finalElmJson = updateSourceDirectories(options, userSrc, {
     ...reviewElmJson,
     dependencies

--- a/lib/build.js
+++ b/lib/build.js
@@ -326,9 +326,13 @@ async function createTemplateProject(
     dependencies
   });
   const finalElmJsonAsString = JSON.stringify(finalElmJson, null, 4);
-  return FS.writeFile(elmJsonPath, finalElmJsonAsString).then(() =>
-    Benchmark.end(options, 'Create template project')
-  );
+  if (previousElmJson !== finalElmJsonAsString) {
+    // We only write the elm.json file if we detect that it's different from the one in the build folder.
+    // This improves performance because if the Elm compiler detects that the elm.json file has not changed,
+    // it will be using its cached assets.
+    await FS.writeFile(elmJsonPath, finalElmJsonAsString);
+  }
+  Benchmark.end(options, 'Create template project');
 }
 
 function updateSourceDirectories(options, userSrc, elmJson) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -314,13 +314,14 @@ async function createTemplateProject(
   const elmJsonPath = path.join(projectFolder, 'elm.json');
 
   // Load review project's elm.json file contents
-  const dependencies = await TemplateDependencies.get(
-    options,
-    reviewElmJson.dependencies,
-    reviewElmJsonPath
-  );
-  await FS.mkdirp(path.dirname(elmJsonPath));
-  const previousElmJson = await FS.readFile(elmJsonPath).catch(() => null);
+  const [dependencies, previousElmJson] = await Promise.all([
+    TemplateDependencies.get(
+      options,
+      reviewElmJson.dependencies,
+      reviewElmJsonPath
+    ),
+    FS.readFile(elmJsonPath).catch(() => null)
+  ]);
   const finalElmJson = updateSourceDirectories(options, userSrc, {
     ...reviewElmJson,
     dependencies
@@ -330,8 +331,10 @@ async function createTemplateProject(
     // We only write the elm.json file if we detect that it's different from the one in the build folder.
     // This improves performance because if the Elm compiler detects that the elm.json file has not changed,
     // it will be using its cached assets.
+    await FS.mkdirp(path.dirname(elmJsonPath));
     await FS.writeFile(elmJsonPath, finalElmJsonAsString);
   }
+
   Benchmark.end(options, 'Create template project');
 }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -155,7 +155,7 @@ I can help set you up with an initial configuration if you run ${chalk.magenta('
       )}`
     );
   } else {
-    const buildFolder = path.join(options.buildFolder(), 'project');
+    const buildFolder = path.join(options.buildFolder(), 'review-project');
     Debug.log('Starting review application build');
 
     const buildResult = await Promise.all([

--- a/lib/build.js
+++ b/lib/build.js
@@ -232,7 +232,7 @@ async function buildFromGitHubTemplate(options, template) {
 
     validateElmReviewVersion(options, reviewElmJsonPath, reviewElmJson);
 
-    const buildFolder = temp.mkdirSync('elm-review-app');
+    const buildFolder = path.join(options.buildFolder(), 'template');
 
     Spinner.setText('Downloading configuration files');
     // Download all files from the template

--- a/lib/build.js
+++ b/lib/build.js
@@ -155,7 +155,7 @@ I can help set you up with an initial configuration if you run ${chalk.magenta('
       )}`
     );
   } else {
-    const buildFolder = options.buildFolder();
+    const buildFolder = path.join(options.buildFolder(), 'project');
     Debug.log('Starting review application build');
 
     const buildResult = await Promise.all([
@@ -172,7 +172,7 @@ I can help set you up with an initial configuration if you run ${chalk.magenta('
       Benchmark.start(options, 'Compile review project');
       return compileElmProject(
         options,
-        path.join(buildFolder, 'project'),
+        buildFolder,
         elmModulePath,
         [`${templateSrc}/Elm/Review/Main.elm`],
         elmBinary,
@@ -260,7 +260,7 @@ async function buildFromGitHubTemplate(options, template) {
         options,
         reviewElmJsonPath,
         buildFolder,
-        buildFolder,
+        path.join(buildFolder, 'project'),
         reviewElmJsonWithReplacedParentDirectories
       )
     ]).then(([elmBinary]) => {
@@ -297,7 +297,7 @@ async function buildFromGitHubTemplate(options, template) {
  * @param {Options} options
  * @param {Path} reviewElmJsonPath
  * @param {Path} userSrc
- * @param {Path} dest
+ * @param {Path} projectFolder
  * @param {ReviewElmJson} reviewElmJson
  * @returns {Promise<void>}
  */
@@ -305,12 +305,11 @@ async function createTemplateProject(
   options,
   reviewElmJsonPath,
   userSrc,
-  dest,
+  projectFolder,
   reviewElmJson
 ) {
   Benchmark.start(options, 'Create template project');
   // Destination directories
-  const projectFolder = path.join(dest, 'project');
   const elmJsonPath = path.join(projectFolder, 'elm.json');
 
   // Load review project's elm.json file contents

--- a/lib/build.js
+++ b/lib/build.js
@@ -320,20 +320,17 @@ async function createTemplateProject(
     reviewElmJsonPath
   );
   await FS.mkdirp(path.dirname(elmJsonPath));
-  return writeElmJsonFile(options, userSrc, elmJsonPath, {
+  const finalElmJson = updateSourceDirectories(options, userSrc, {
     ...reviewElmJson,
     dependencies
-  }).then(() => Benchmark.end(options, 'Create template project'));
+  });
+  return writeElmJsonFile(elmJsonPath, finalElmJson).then(() =>
+    Benchmark.end(options, 'Create template project')
+  );
 }
 
-function writeElmJsonFile(options, userSrc, elmJsonPath, elmJson) {
-  const elmJsonWithSourceDirectories = updateSourceDirectories(
-    options,
-    userSrc,
-    elmJson
-  );
-
-  return FS.writeJson(elmJsonPath, elmJsonWithSourceDirectories, 4);
+function writeElmJsonFile(elmJsonPath, elmJson) {
+  return FS.writeJson(elmJsonPath, elmJson, 4);
 }
 
 function updateSourceDirectories(options, userSrc, elmJson) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -155,7 +155,7 @@ I can help set you up with an initial configuration if you run ${chalk.magenta('
       )}`
     );
   } else {
-    const buildFolder = temp.mkdirSync('elm-review-app');
+    const buildFolder = options.buildFolder();
     Debug.log('Starting review application build');
 
     const buildResult = await Promise.all([

--- a/lib/build.js
+++ b/lib/build.js
@@ -325,13 +325,10 @@ async function createTemplateProject(
     ...reviewElmJson,
     dependencies
   });
-  return writeElmJsonFile(elmJsonPath, finalElmJson).then(() =>
+  const finalElmJsonAsString = JSON.stringify(finalElmJson, null, 4);
+  return FS.writeFile(elmJsonPath, finalElmJsonAsString).then(() =>
     Benchmark.end(options, 'Create template project')
   );
-}
-
-function writeElmJsonFile(elmJsonPath, elmJson) {
-  return FS.writeJson(elmJsonPath, elmJson, 4);
 }
 
 function updateSourceDirectories(options, userSrc, elmJson) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -225,6 +225,7 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
     template,
     initPath,
     suppressedErrorsFolder,
+    buildFolder: () => path.join(elmStuffFolder(), 'build-project'),
     elmModulePath: (appHash /* : string */) =>
       path.join(elmStuffFolder(), 'review-applications', `${appHash}.js`),
     elmParserPath: (elmSyntaxVersion /* : string */) =>

--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -183,12 +183,12 @@ function downloadSourceDirectories(
   options,
   template,
   commit,
-  buildFolder,
+  basePath,
   reviewElmJson
 ) {
   return Promise.all(
     reviewElmJson['source-directories'].map((sourceDirectory) =>
-      downloadDirectory(options, template, commit, buildFolder, sourceDirectory)
+      downloadDirectory(options, template, commit, basePath, sourceDirectory)
     )
   );
 }

--- a/lib/types/options.d.ts
+++ b/lib/types/options.d.ts
@@ -40,6 +40,7 @@ export type Options = {
   template: Template | null;
   initPath: () => Path;
   suppressedErrorsFolder: () => Path;
+  buildFolder: () => Path;
   elmModulePath: (string) => Path;
   elmParserPath: (string) => Path;
   generatedCodePackageJson: () => Path;


### PR DESCRIPTION
Before this PR, when we compiled the configuration, we created a temporary folder every time.

@dillonkearns gave a tip on the [`elm-watch` Elm Radio episode](https://elm-radio.com/episode/elm-watch/#00-30-45), where he said that if the Elm compiler notices that `elm.json` has changed, then it will recompute a lot of things. Meaning that if you want it to be faster, you'd avoid touching that file. So we stop building a temporary folder, and instead we have the build-folder somewhere in `elm-stuff`, where we also keep all the elmi/elmo files the compiler makes.

This shaves about 0.5s-0.7s on my machine when the configuration changes (tested with `elm-review --force-rebuild`) in the right conditions, so this is a nice improvement :blush: 

This should also be done for the parser application and for `--template` configurations, but that will be for a later PR.

@dillonkearns If you have additional advice, I'm all eyes :eyes: 