### PR TITLE
Use a folder in elm-stuff to build the parser app

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const temp = require('temp');
 const chalk = require('chalk');
 const wrap = require('wrap-ansi');
 const {hashElement} = require('folder-hash');
@@ -559,7 +558,6 @@ async function buildElmParser(options, reviewElmJson) {
 
   Debug.log(`Building parser app for elm-syntax v${elmSyntaxVersion}`);
 
-  const buildFolder = temp.mkdirSync('elm-parser-app');
   const parseElmElmJsonPath = path.resolve(parseElmFolder, 'elm.json');
   const parseElmElmJson = await FS.readJsonFile(parseElmElmJsonPath).catch(
     (error) => {
@@ -582,6 +580,8 @@ https://github.com/jfmengels/node-elm-review/issues/new
       return Promise.reject(error);
     }
   );
+
+  const buildFolder = options.buildFolderForParserApp();
 
   const [elmBinary] = await Promise.all([
     getElmBinary(options),
@@ -625,6 +625,7 @@ async function createParserElmJsonFile(
     elmSyntaxVersion
   );
 
+  await FS.mkdirp(buildFolder);
   return FS.writeFile(
     path.resolve(buildFolder, 'elm.json'),
     JSON.stringify(

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,7 +8,6 @@ if (!process.argv.includes('--no-color')) {
 }
 
 const path = require('path');
-const temp = require('temp');
 const Help = require('./help');
 const Init = require('./init');
 const Builder = require('./build');
@@ -31,7 +30,6 @@ process.on('unhandledRejection', errorHandler);
 
 function errorHandler(err) {
   Spinner.fail(undefined);
-  temp.cleanupSync();
   let userSrc = null;
   try {
     userSrc = options.userSrc();

--- a/lib/options.js
+++ b/lib/options.js
@@ -226,6 +226,8 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
     initPath,
     suppressedErrorsFolder,
     buildFolder: () => path.join(elmStuffFolder(), 'build-project'),
+    buildFolderForParserApp: () =>
+      path.join(elmStuffFolder(), 'parser-app-build-project'),
     elmModulePath: (appHash /* : string */) =>
       path.join(elmStuffFolder(), 'review-applications', `${appHash}.js`),
     elmParserPath: (elmSyntaxVersion /* : string */) =>

--- a/lib/types/options.d.ts
+++ b/lib/types/options.d.ts
@@ -41,6 +41,7 @@ export type Options = {
   initPath: () => Path;
   suppressedErrorsFolder: () => Path;
   buildFolder: () => Path;
+  buildFolderForParserApp: () => Path;
   elmModulePath: (string) => Path;
   elmParserPath: (string) => Path;
   generatedCodePackageJson: () => Path;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "prompts": "^2.2.1",
         "rimraf": "^5.0.0",
         "strip-ansi": "^6.0.0",
-        "temp": "^0.9.1",
         "terminal-link": "^2.1.1",
         "which": "^2.0.2",
         "wrap-ansi": "^6.2.0"
@@ -5625,26 +5624,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/temp": {
-      "version": "0.9.1",
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/temp/node_modules/rimraf": {
-      "version": "2.6.3",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "license": "MIT",
@@ -9649,20 +9628,6 @@
     "symbol-tree": {
       "version": "3.2.4",
       "dev": true
-    },
-    "temp": {
-      "version": "0.9.1",
-      "requires": {
-        "rimraf": "~2.6.2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.6.3",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
     },
     "terminal-link": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "prompts": "^2.2.1",
     "rimraf": "^5.0.0",
     "strip-ansi": "^6.0.0",
-    "temp": "^0.9.1",
     "terminal-link": "^2.1.1",
     "which": "^2.0.2",
     "wrap-ansi": "^6.2.0"


### PR DESCRIPTION
Similar to #121, we now re-use an existing folder meant to build different versions of the parser app. This reduces the time spent compiling the parser app when the version of elm-syntax changes.