### PR TITLE
Add types to promisify-port.js

### DIFF
--- a/lib/promisify-port.js
+++ b/lib/promisify-port.js
@@ -1,24 +1,15 @@
 /**
- * @callback HandlerFn
- * @param {function} handler
- * @return {void}
- */
-
-/**
  * Allows to treat a pair of ports as one promise.
  * It sends a message into `sendTrough` and resolves the promise with the first "response" data on `subscribeTo`.
- *
  * @template DataIn,DataOut
- * @param {object} obj
- * @param {{ subscribe: HandlerFn, unsubscribe: HandlerFn}} obj.subscribeTo - port to receive the action result
- * @param {{send: (data: DataIn) => void }} obj.sendThrough - port to trigger an action
- * @param {DataIn} obj.data - to trigger an action
+ * @param {import("./types/promisify-port").PortsToPromise<DataIn, DataOut>} obj
  * @returns {PromiseLike<DataOut>}
  */
 function promisifyPort({subscribeTo, sendThrough, data}) {
   return new Promise((resolve) => {
     /**
      * @param {DataOut} result
+     * @returns void
      */
     const handler = (result) => {
       subscribeTo.unsubscribe(handler);

--- a/lib/promisify-port.js
+++ b/lib/promisify-port.js
@@ -1,5 +1,25 @@
+/**
+ * @callback HandlerFn
+ * @param {function} handler
+ * @return {void}
+ */
+
+/**
+ * Allows to treat a pair of ports as one promise.
+ * It sends a message into `sendTrough` and resolves the promise with the first "response" data on `subscribeTo`.
+ *
+ * @template DataIn,DataOut
+ * @param {object} obj
+ * @param {{ subscribe: HandlerFn, unsubscribe: HandlerFn}} obj.subscribeTo - port to receive the action result
+ * @param {{send: (data: DataIn) => void }} obj.sendThrough - port to trigger an action
+ * @param {DataIn} obj.data - to trigger an action
+ * @returns {PromiseLike<DataOut>}
+ */
 function promisifyPort({subscribeTo, sendThrough, data}) {
   return new Promise((resolve) => {
+    /**
+     * @param {DataOut} result
+     */
     const handler = (result) => {
       subscribeTo.unsubscribe(handler);
       resolve(result);

--- a/lib/types/promisify-port.d.ts
+++ b/lib/types/promisify-port.d.ts
@@ -1,0 +1,16 @@
+export type PortsToPromise<DataIn, DataOut> = {
+  subscribeTo: PortFromElm<DataOut>;
+  sendThrough: PortToElm<DataIn>;
+  data: DataIn;
+};
+
+export type PortFromElm<DataOut> = {
+  subscribe: CallbackFn<DataOut>;
+  unsubscribe: CallbackFn<DataOut>;
+};
+
+type CallbackFn<T> = (cb: (data: T) => void) => void;
+
+export type PortToElm<DataIn> = {
+  send: (data: DataIn) => void;
+};

--- a/tsconfig.no-implicit-any.json
+++ b/tsconfig.no-implicit-any.json
@@ -11,6 +11,7 @@
     "lib/hash.js",
     "lib/help.js",
     "lib/os-helpers.js",
+    "lib/promisify-port.js",
     "jest.config.js"
   ]
 }


### PR DESCRIPTION
This PR is a step towards https://github.com/jfmengels/node-elm-review/issues/125, and adds types to `lib/promisify-port.js`.

I was not sure about the descriptive comments, feel free to change them however you see fit.

I never wrote jsdoc comments to such an extent before, adding a `.d.ts` file would have been easier for me. 
Thank you for the challenge :laughing: 