### PR TITLE
Add types to min-version.js

### DIFF
--- a/lib/min-version.js
+++ b/lib/min-version.js
@@ -3,6 +3,12 @@ const chalk = require('chalk');
 const PathHelpers = require('./path-helpers');
 const ErrorMessage = require('./error-message');
 
+/**
+ * @typedef { import("./types/options").Options } Options
+ * @typedef { import("./types/path").Path } Path
+ * @typedef { import("./types/min-version").VersionString } VersionString
+ */
+
 const minimalVersion = {major: 2, minor: 13};
 // prettier-ignore
 const supportedRange = `${minimalVersion.major}.${minimalVersion.minor}.0 <= v < ${minimalVersion.major + 1}.0.0`
@@ -13,6 +19,13 @@ module.exports = {
   supportedRange
 };
 
+/**
+ * If given an input version string smaller than the hardcoded `minimalVersion`,
+ * it will return the minimal version.
+ * Otherwise, the input version string is returned.
+ * @param {VersionString} version - input version string, e.g. "1.0"
+ * @returns {VersionString}
+ */
 function updateToAtLeastMinimalVersion(version) {
   const [major, minor] = version.split('.');
 
@@ -32,6 +45,13 @@ function updateToAtLeastMinimalVersion(version) {
   return `${minimalVersion.major}.${minimalVersion.minor}.0`;
 }
 
+/**
+ * Throws an error if the passed elm-review version is not compatible with this runner.
+ * @param {Options} options
+ * @param {Path} elmJsonPath - path to an elm.json file
+ * @param {VersionString} version - version string, e.g. "1.0"
+ * @returns void
+ */
 function validate(options, elmJsonPath, version) {
   const [major, minor] = version.split('.');
 

--- a/lib/types/min-version.d.ts
+++ b/lib/types/min-version.d.ts
@@ -1,0 +1,4 @@
+/**
+ * A major.minor version string, e.g. "1.0"
+ */
+export type VersionString = string;

--- a/tsconfig.no-implicit-any.json
+++ b/tsconfig.no-implicit-any.json
@@ -10,6 +10,7 @@
     "lib/flags.js",
     "lib/hash.js",
     "lib/help.js",
+    "lib/min-version.js",
     "lib/os-helpers.js",
     "lib/path-helpers.js",
     "lib/promisify-port.js",

--- a/tsconfig.no-implicit-any.json
+++ b/tsconfig.no-implicit-any.json
@@ -11,6 +11,7 @@
     "lib/hash.js",
     "lib/help.js",
     "lib/os-helpers.js",
+    "lib/path-helpers.js",
     "lib/promisify-port.js",
     "jest.config.js"
   ]


### PR DESCRIPTION
As another tiny step towards https://github.com/jfmengels/node-elm-review/issues/125, this PR adds types to lib/min-version.js.