### PR TITLE
Replace fast-levenshtein with fastest-levenshtein

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -2,7 +2,7 @@ const path = require('path');
 const chalk = require('chalk');
 const findUp = require('find-up');
 const minimist = require('minimist');
-const levenshtein = require('fast-levenshtein');
+const levenshtein = require('fastest-levenshtein');
 const packageJson = require('../package.json');
 const Flags = require('./flags');
 const ErrorMessage = require('./error-message');
@@ -446,7 +446,7 @@ function suggestions(flag) {
   return Flags.flags
     .map((f) => ({
       ...f,
-      distance: levenshtein.get(flag, f.name)
+      distance: levenshtein.distance(flag, f.name)
     }))
     .sort((a, b) => {
       if (a.distance < b.distance) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "chokidar": "^3.5.2",
         "cross-spawn": "^7.0.3",
         "elm-tooling": "^1.6.0",
-        "fast-levenshtein": "^3.0.0",
         "find-up": "^4.1.0",
         "folder-hash": "^3.3.0",
         "fs-extra": "^9.0.0",
@@ -3376,17 +3375,6 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "fastest-levenshtein": "^1.0.7"
-      }
-    },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.12",
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -8831,15 +8819,6 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "3.0.0",
-      "requires": {
-        "fastest-levenshtein": "^1.0.7"
-      }
-    },
-    "fastest-levenshtein": {
-      "version": "1.0.12"
     },
     "fastq": {
       "version": "1.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
       },
       "devDependencies": {
         "@types/chalk": "^2.2.0",
-        "@types/fast-levenshtein": "^0.0.2",
         "@types/jest": "^29.5.1",
         "@types/minimist": "^1.2.2",
         "@types/node": "^18.15.13",
@@ -1163,12 +1162,6 @@
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "license": "MIT"
-    },
-    "node_modules/@types/fast-levenshtein": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.2.tgz",
-      "integrity": "sha512-h9AGeNlFimLtFUlEZgk+hb3LUT4tNHu8y0jzCUeTdi1BM4e86sBQs/nQYgHk70ksNyNbuLwpymFAXkb0GAehmw==",
-      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -7416,12 +7409,6 @@
     },
     "@types/color-name": {
       "version": "1.1.1"
-    },
-    "@types/fast-levenshtein": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.2.tgz",
-      "integrity": "sha512-h9AGeNlFimLtFUlEZgk+hb3LUT4tNHu8y0jzCUeTdi1BM4e86sBQs/nQYgHk70ksNyNbuLwpymFAXkb0GAehmw==",
-      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "chokidar": "^3.5.2",
         "cross-spawn": "^7.0.3",
         "elm-tooling": "^1.6.0",
+        "fastest-levenshtein": "^1.0.16",
         "find-up": "^4.1.0",
         "folder-hash": "^3.3.0",
         "fs-extra": "^9.0.0",
@@ -3376,6 +3377,14 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -8819,6 +8828,11 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "dev": true
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="
     },
     "fastq": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",
-    "@types/fast-levenshtein": "^0.0.2",
     "@types/jest": "^29.5.1",
     "@types/minimist": "^1.2.2",
     "@types/node": "^18.15.13",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "chokidar": "^3.5.2",
     "cross-spawn": "^7.0.3",
     "elm-tooling": "^1.6.0",
+    "fastest-levenshtein": "^1.0.16",
     "find-up": "^4.1.0",
     "folder-hash": "^3.3.0",
     "fs-extra": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "chokidar": "^3.5.2",
     "cross-spawn": "^7.0.3",
     "elm-tooling": "^1.6.0",
-    "fast-levenshtein": "^3.0.0",
     "find-up": "^4.1.0",
     "folder-hash": "^3.3.0",
     "fs-extra": "^9.0.0",


### PR DESCRIPTION
This PR relates to #82 and removes one direct dependency and updates an indirect one.

fast-levenshtein@3.0.0 currently installs fastest-levenshtein@1.0.12 according to the package-lock.json.  
I updated to 1.0.16 because I saw no indication that the compiled typescript output should no longer be compatible to node.js 10.0.0.

Currently, elm-review uses `levenshtein.get(flag, f.name)` and does not pass the option to use locale-sensitive string comparisons. This means that `fast-levenshtein` does this:

```js
var levenshtein = require('fastest-levenshtein');
...
var Levenshtein = {
    get: function(str1, str2, options) {
        if (options.collate) { ... }
        return levenshtein.distance(str1, str2);
    }
    ...
}
```
See https://github.com/hiddentao/fast-levenshtein/blob/master/levenshtein.js#L84

I think it should not create a merge conflict with #126, but I'm not sure.