### PR TITLE
Add types to state.js

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 
 /**
+ * @typedef { import("./types/content").ElmFile } ElmFile
+ * @typedef { import("./types/content").ElmJsonData } ElmJsonData
+ * @typedef { import("./types/state").FileId } FileId
+ * @typedef { import("./types/state").FilesProposedByCurrentFix } FilesProposedByCurrentFix
+ * @typedef { import("./types/state").FileWithContent } FileWithContent
  * @typedef { import("./types/state").Model } Model
  * @typedef { import("./types/state").Msg } Msg
  * @typedef { import("./types/options").Options } Options
+ * @typedef { import("./types/path").Path } Path
+ * @typedef { import("./types/content").Readme } Readme
  */
 
 const Options = require('./options');
@@ -206,6 +213,10 @@ function markReviewAsComplete() {
   }
 }
 
+/**
+ * @param {Array<ElmFile|FileWithContent>} files
+ * @returns void
+ */
 function updateFilesInCache(files) {
   files.forEach((file) => {
     if (file.path.endsWith('.elm')) {
@@ -221,26 +232,45 @@ function updateFilesInCache(files) {
 
 // ACCESS
 
+/**
+ * @returns {Options}
+ */
 function getOptions() {
   return options;
 }
 
+/**
+ * @param {Path} filePath
+ * @returns {ElmFile|undefined}
+ */
 function getFileFromMemoryCache(filePath) {
   return model.elmFilesCacheForWatch.get(filePath);
 }
 
+/**
+ * @returns {FilesProposedByCurrentFix}
+ */
 function filesProposedByCurrentFix() {
   return model.filesProposedByCurrentFix;
 }
 
 // MESSAGES
 
+/**
+ * @returns {Model}
+ */
 function initializedApp() {
   return update({
     $: 'initializedApp'
   });
 }
 
+/**
+ * @template T
+ * @param {import("./types/promisify-port").PortFromElm<T>} port
+ * @param {(data: T) => void} subscriptionFunction
+ * @returns {Model}
+ */
 function subscribe(port, subscriptionFunction) {
   port.subscribe(subscriptionFunction);
 
@@ -250,6 +280,10 @@ function subscribe(port, subscriptionFunction) {
   });
 }
 
+/**
+ * @param {0|1} exitCode
+ * @returns {Model}
+ */
 function exitRequested(exitCode) {
   return update({
     $: 'exitRequested',
@@ -257,6 +291,10 @@ function exitRequested(exitCode) {
   });
 }
 
+/**
+ * @param {Array<ElmFile>} files
+ * @returns {Model}
+ */
 function filesWereUpdated(files) {
   return update({
     $: 'filesWereUpdated',
@@ -264,6 +302,10 @@ function filesWereUpdated(files) {
   });
 }
 
+/**
+ * @param {Readme} readme
+ * @returns {boolean}
+ */
 function readmeChanged(readme) {
   const hasChanged = !model.readme || readme.content !== model.readme.content;
 
@@ -275,12 +317,18 @@ function readmeChanged(readme) {
   return hasChanged;
 }
 
+/**
+ * @returns {Model}
+ */
 function buildRestarted() {
   return update({
     $: 'buildRestarted'
   });
 }
 
+/**
+ * @returns {boolean}
+ */
 function requestReview() {
   let canRunReview = null;
   switch (model.reviewState.type) {
@@ -312,6 +360,9 @@ function requestReview() {
   return canRunReview;
 }
 
+/**
+ * @returns {boolean}
+ */
 function reviewFinished() {
   update({
     $: 'reviewFinished'
@@ -320,6 +371,10 @@ function reviewFinished() {
   return shouldReReview;
 }
 
+/**
+ * @param {FileId} fileId
+ * @returns {Model}
+ */
 function writingToFileSystemCacheStarted(fileId) {
   return update({
     $: 'writingToFileSystemCacheStarted',
@@ -327,6 +382,10 @@ function writingToFileSystemCacheStarted(fileId) {
   });
 }
 
+/**
+ * @param {FileId} fileId
+ * @returns {Model}
+ */
 function writingToFileSystemCacheFinished(fileId) {
   return update({
     $: 'writingToFileSystemCacheFinished',
@@ -334,6 +393,10 @@ function writingToFileSystemCacheFinished(fileId) {
   });
 }
 
+/**
+ * @param {FilesProposedByCurrentFix} changedFiles
+ * @returns {boolean}
+ */
 function fixProposalReceived(changedFiles) {
   update({
     $: 'fixProposalReceived',
@@ -344,12 +407,18 @@ function fixProposalReceived(changedFiles) {
   return shouldReReview;
 }
 
+/**
+ * @returns {Model}
+ */
 function fixWasAccepted() {
   return update({
     $: 'fixWasAccepted'
   });
 }
 
+/**
+ * @returns {Model}
+ */
 function fixWasRefused() {
   return update({
     $: 'fixWasRefused'

--- a/lib/state.js
+++ b/lib/state.js
@@ -223,8 +223,9 @@ function updateFilesInCache(files) {
       model.elmFilesCacheForWatch.set(file.path, {
         path: file.path,
         source: file.source,
-        ast: file.ast,
-        lastUpdatedTime: file.lastUpdatedTime
+        ast: 'ast' in file ? file.ast : undefined,
+        lastUpdatedTime:
+          'lastUpdatedTime' in file ? file.lastUpdatedTime : undefined
       });
     }
   });

--- a/lib/state.js
+++ b/lib/state.js
@@ -304,10 +304,11 @@ function filesWereUpdated(files) {
 }
 
 /**
- * @param {Readme} readme
+ * @param {Readme|null} readme
  * @returns {boolean}
  */
 function readmeChanged(readme) {
+  if (!readme) return false;
   const hasChanged = !model.readme || readme.content !== model.readme.content;
 
   update({

--- a/lib/types/state.d.ts
+++ b/lib/types/state.d.ts
@@ -23,7 +23,9 @@ export type ExitRequest = {
 
 export type AppUnsubscribeFunction = function;
 
-export type FilesProposedByCurrentFix = Array<{path: Path; source: Source}>;
+export type FilesProposedByCurrentFix = Array<FileWithContent>;
+
+export type FileWithContent = {path: Path; source: Source};
 
 export type FileId = string;
 

--- a/tsconfig.no-implicit-any.json
+++ b/tsconfig.no-implicit-any.json
@@ -14,6 +14,7 @@
     "lib/os-helpers.js",
     "lib/path-helpers.js",
     "lib/promisify-port.js",
+    "lib/state.js",
     "lib/styled-message.js",
     "jest.config.js"
   ]


### PR DESCRIPTION
Relates to #125 and adds types to lib/state.js

The changes actually depend on #125 which adds the definitions to `lib/options.js` . Without it, the type checker will report errors about the options file.  
For development, I added the line `// @ts-nocheck part https://github.com/jfmengels/node-elm-review/pull/126` to the top of `lib/options.js` to ignore it.

I wasn't sure if opening the PR makes sense, but I already forgot most of what I was doing there and that won't get any better :smile: 