### PR TITLE
Remove fs-extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Removed the dependency on `fs-extra`.
+
 ## [2.11.1] - 2024-03-16
 
 - Fixed a crash when running in watch mode related to not being able to fetch cache results.

--- a/lib/fs-wrapper.js
+++ b/lib/fs-wrapper.js
@@ -1,6 +1,9 @@
+const path = require('path');
 const util = require('util');
 const fs = require('graceful-fs');
 const {rimraf} = require('rimraf');
+
+const copyFile = util.promisify(fs.copyFile);
 
 // TODO When we drop support for Node.js v10, use natively promisified functions
 
@@ -87,6 +90,20 @@ function mkdirpSync(dir) {
   fs.mkdirSync(dir, {recursive: true});
 }
 
+/**
+ * Copy files from srcFolder to destFolder.
+ * @param {Path} srcFolder
+ * @param {Path} destFolder
+ * @param {Path[]} files
+ * @returns {Promise<void>}
+ */
+function copyFiles(srcFolder, destFolder, files) {
+  const promises = files.map((file) =>
+    copyFile(path.join(srcFolder, file), path.join(destFolder, file))
+  );
+  return Promise.all(promises).then(() => undefined);
+}
+
 module.exports = {
   readFile,
   readJsonFile,
@@ -97,6 +114,8 @@ module.exports = {
 
   mkdirp,
   mkdirpSync,
+
+  copyFiles,
 
   readdir: util.promisify(fs.readdir),
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const fsExtra = require('fs-extra');
 const chalk = require('chalk');
 const prompts = require('prompts');
 const FS = require('./fs-wrapper');
@@ -155,7 +154,7 @@ async function createElmJson(options, directory) {
 }
 
 function createReviewConfig(directory, template) {
-  fsExtra.copyFileSync(
+  fs.copyFileSync(
     path.join(__dirname, '../init-templates/', template),
     path.join(directory, 'ReviewConfig.elm')
   );

--- a/lib/new-package.js
+++ b/lib/new-package.js
@@ -3,7 +3,6 @@ const path = require('path');
 const childProcess = require('child_process');
 const chalk = require('chalk');
 const prompts = require('prompts');
-const fsExtra = require('fs-extra');
 const Init = require('./init');
 const Spinner = require('./spinner');
 const NewRule = require('./new-rule');
@@ -236,10 +235,13 @@ ElmjutsuDumMyM0DuL3.elm
   );
 
   Spinner.succeedAndNowDo('Adding GitHub Actions');
-  fsExtra.copySync(
+  const githubDestFiles = path.join(dir, '.github/');
+  FS.mkdirpSync(path.join(githubDestFiles, 'ISSUE_TEMPLATE'));
+  FS.mkdirpSync(path.join(githubDestFiles, 'workflows'));
+  await FS.copyFiles(
     path.join(__dirname, '../new-package/github/'),
-    path.join(dir, '.github/'),
-    {overwrite: true}
+    githubDestFiles,
+    ['ISSUE_TEMPLATE/new-rule-idea.md', 'workflows/test.yml']
   );
 
   Spinner.succeedAndNowDo(
@@ -277,12 +279,10 @@ ElmjutsuDumMyM0DuL3.elm
   Spinner.succeedAndNowDo('Adding maintenance scripts');
   const maintenancePath = path.join(process.cwd(), packageName, 'maintenance');
   FS.mkdirpSync(maintenancePath);
-  fsExtra.copySync(
+  await FS.copyFiles(
     path.join(__dirname, '../new-package/maintenance/'),
     maintenancePath,
-    {
-      overwrite: true
-    }
+    ['MAINTENANCE.md', 'update-examples-from-preview.js']
   );
 
   const packageTests = path.join(
@@ -290,13 +290,16 @@ ElmjutsuDumMyM0DuL3.elm
     packageName,
     'elm-review-package-tests'
   );
-  FS.mkdirpSync(packageTests);
-  fsExtra.copySync(
-    path.join(__dirname, '../new-package/elm-review-package-tests/'),
+  FS.mkdirpSync(path.join(packageTests, 'helpers'));
+  await FS.copyFiles(
+    path.join(__dirname, '../new-package/elm-review-package-tests'),
     packageTests,
-    {
-      overwrite: true
-    }
+    [
+      'check-previews-compile.js',
+      'check-examples-were-updated.js',
+      'helpers/ansi.js',
+      'helpers/find-configurations.js'
+    ]
   );
 
   Spinner.succeed();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "fastest-levenshtein": "^1.0.16",
         "find-up": "^4.1.0",
         "folder-hash": "^3.3.0",
-        "fs-extra": "^9.0.0",
         "glob": "^7.1.4",
         "got": "^11.8.5",
         "graceful-fs": "^4.2.11",
@@ -1775,13 +1774,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "27.3.1",
       "dev": true,
@@ -3483,36 +3475,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "9.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/fs-extra/node_modules/jsonfile": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^1.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/fs-extra/node_modules/universalify": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -7799,9 +7761,6 @@
       "version": "0.4.0",
       "dev": true
     },
-    "at-least-node": {
-      "version": "1.0.0"
-    },
     "babel-jest": {
       "version": "27.3.1",
       "dev": true,
@@ -8854,27 +8813,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
-      }
-    },
-    "fs-extra": {
-      "version": "9.0.0",
-      "requires": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
-      },
-      "dependencies": {
-        "jsonfile": {
-          "version": "6.0.1",
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
-          }
-        },
-        "universalify": {
-          "version": "1.0.0"
-        }
       }
     },
     "fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "fastest-levenshtein": "^1.0.16",
     "find-up": "^4.1.0",
     "folder-hash": "^3.3.0",
-    "fs-extra": "^9.0.0",
     "glob": "^7.1.4",
     "got": "^11.8.5",
     "graceful-fs": "^4.2.11",


### PR DESCRIPTION
Fixes #120

Removes the dependency on `fs-extra`. As @lydell pointed out, `fs.copyFileSync` already exists in core `fs`.
`fs.copy` (which copies entire directories) however doesn't. I chose to fix this by hardcoding which files to copy (which is faster, though potentially error-prone :shrug:)

Now that `fs-extra` is absent from the dependencies, `tsc` complains about the files that reference it in the `new-package/` folder. Those files are copied over and not included, but do use `fs-extra` (mostly because of the "need" to copy entire directories, ideally in a sync manner). I don't know how to suppress this error, and if I ignore the file, then ESLint complains that it can't parse it.

If anyone has an idea on how to fix this, I'm all ears!