### PR TITLE
Allow relative AND absolute paths when ignoring directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- The `--ignore-dirs` and `--ignore-files` flags now support absolute paths. Thanks [@jamesrweb](https://github.com/jamesrweb)!
+
 ## [2.11.1] - 2024-03-16
 
 - Fixed a crash when running in watch mode related to not being able to fetch cache results.

--- a/lib/options.js
+++ b/lib/options.js
@@ -233,12 +233,10 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
     report: args.report === 'json' || args.report === 'ndjson' ? 'json' : null,
     reportOnOneLine: args.report === 'ndjson',
     rulesFilter: listOfStrings(args.rules),
-    ignoredDirs: (listOfStrings(args['ignore-dirs']) || []).map(
-      absolutePathsToRelative
-    ),
-    ignoredFiles: (listOfStrings(args['ignore-files']) || []).map(
-      absolutePathsToRelative
-    ),
+    ignoredDirs: () =>
+      (listOfStrings(args['ignore-dirs']) || []).map(absolutePathsToRelative),
+    ignoredFiles: () =>
+      (listOfStrings(args['ignore-files']) || []).map(absolutePathsToRelative),
 
     // TEMPORARY WORKAROUNDS
     ignoreProblematicDependencies: args['ignore-problematic-dependencies'],

--- a/lib/options.js
+++ b/lib/options.js
@@ -199,7 +199,7 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
    */
   function absolutePathsToRelative(filePath) {
     if (path.isAbsolute(filePath)) {
-      return path.relative(filePath, projectToReview());
+      return path.relative(projectToReview(), filePath);
     }
 
     return filePath;

--- a/lib/options.js
+++ b/lib/options.js
@@ -9,7 +9,6 @@ const levenshtein = require('fastest-levenshtein');
 const packageJson = require('../package.json');
 const Flags = require('./flags');
 const ErrorMessage = require('./error-message');
-const {isAbsolute, relative} = require('path');
 
 /**
  * @typedef { import("minimist").ParsedArgs } ParsedArgs
@@ -195,15 +194,15 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
   /**
    * Converts absolute to relative paths.
    *
-   * @param {Path} path
+   * @param {Path} filePath
    * @returns {Path}
    */
-  function absolutePathsToRelative(path) {
-    if (isAbsolute(path)) {
-      return relative(path, projectToReview());
+  function absolutePathsToRelative(filePath) {
+    if (path.isAbsolute(filePath)) {
+      return path.relative(filePath, projectToReview());
     }
 
-    return path;
+    return filePath;
   }
 
   return {

--- a/lib/options.js
+++ b/lib/options.js
@@ -9,6 +9,7 @@ const levenshtein = require('fastest-levenshtein');
 const packageJson = require('../package.json');
 const Flags = require('./flags');
 const ErrorMessage = require('./error-message');
+const {isAbsolute, relative} = require('path');
 
 /**
  * @typedef { import("minimist").ParsedArgs } ParsedArgs
@@ -191,6 +192,20 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
     license
   };
 
+  /**
+   * Converts absolute to relative paths.
+   *
+   * @param {Path} path
+   * @returns {Path}
+   */
+  function absolutePathsToRelative(path) {
+    if (isAbsolute(path)) {
+      return relative(path, projectToReview());
+    }
+
+    return path;
+  }
+
   return {
     debug: args.debug,
     showBenchmark: args['benchmark-info'],
@@ -219,8 +234,12 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
     report: args.report === 'json' || args.report === 'ndjson' ? 'json' : null,
     reportOnOneLine: args.report === 'ndjson',
     rulesFilter: listOfStrings(args.rules),
-    ignoredDirs: listOfStrings(args['ignore-dirs']) || [],
-    ignoredFiles: listOfStrings(args['ignore-files']) || [],
+    ignoredDirs: (listOfStrings(args['ignore-dirs']) || []).map(
+      absolutePathsToRelative
+    ),
+    ignoredFiles: (listOfStrings(args['ignore-files']) || []).map(
+      absolutePathsToRelative
+    ),
 
     // TEMPORARY WORKAROUNDS
     ignoreProblematicDependencies: args['ignore-problematic-dependencies'],

--- a/lib/result-cache.js
+++ b/lib/result-cache.js
@@ -31,8 +31,8 @@ async function load(options, cacheFolder) {
   if (
     options.debug ||
     options.directoriesToAnalyze.length > 0 ||
-    options.ignoredDirs.length > 0 ||
-    options.ignoredFiles.length > 0
+    options.ignoredDirs().length > 0 ||
+    options.ignoredFiles().length > 0
   ) {
     // TODO Breaking change: When we drop support for Node.js v10, use `globalThis` everywhere instead of `global`
     global.loadResultFromCache = () => null;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -111,8 +111,8 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
     rulesFilter: options.rulesFilter,
     ignoreProblematicDependencies: options.ignoreProblematicDependencies,
     directoriesToAnalyze: options.directoriesToAnalyze,
-    ignoredDirs: options.ignoredDirs,
-    ignoredFiles: options.ignoredFiles,
+    ignoredDirs: options.ignoredDirs(),
+    ignoredFiles: options.ignoredFiles(),
     writeSuppressionFiles: options.directoriesToAnalyze.length === 0
   });
 

--- a/lib/types/options.d.ts
+++ b/lib/types/options.d.ts
@@ -28,8 +28,8 @@ export type Options = {
   report: ReportMode;
   reportOnOneLine: boolean;
   rulesFilter: string[] | null;
-  ignoredDirs: string[];
-  ignoredFiles: string[];
+  ignoredDirs: () => string[];
+  ignoredFiles: () => string[];
   ignoreProblematicDependencies: boolean;
   prefilledAnswers: NewPackagePrefilledAnswers;
 


### PR DESCRIPTION
Fixes #149.

Convert absolute paths to be relative to the project being reviewed.