### PR TITLE
fix process.exit calls

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     'test/snapshots',
     'test/temporary',
     'vendor/node-elm-compiler.js',
+    'vendor/exit.js',
     '.eslintrc.js',
     'new-package/elm-review-package-tests/check-previews-compile.js'
   ],

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@
 **/suppressed
 test/**/*.json
 test/temporary/
+vendor/exit.js

--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -11,6 +11,7 @@ const promisifyPort = require('./promisify-port');
 const StyledMessage = require('./styled-message');
 const {startReview} = require('./run-review');
 const ProjectDependencies = require('./project-dependencies');
+const exit = require('../vendor/exit');
 
 /**
  * @typedef { import("./types/options").Options } Options
@@ -90,7 +91,7 @@ function askConfirmationToFixWithOptions(options, app, elmVersion) {
     if (accepted === undefined) {
       // User interrupted the process using Ctrl-C
 
-      process.exit(1);
+      exit(1);
     }
 
     /** @type {FilesProposedByCurrentFix} */

--- a/lib/build.js
+++ b/lib/build.js
@@ -18,6 +18,7 @@ const MinVersion = require('./min-version');
 const ErrorMessage = require('./error-message');
 const RemoteTemplate = require('./remote-template');
 const TemplateDependencies = require('./template-dependencies');
+const exit = require('../vendor/exit');
 
 /**
  * @typedef { import("./types/options").Options } Options
@@ -441,7 +442,7 @@ function compileElmProject(
             return resolve(null);
           }
 
-          process.exit(1);
+          exit(1);
         });
       }
     });
@@ -476,7 +477,7 @@ function compilationError(options, stderr) {
 
     // TODO Handle this better
 
-    process.exit(1);
+    exit(1);
   }
 
   return {

--- a/lib/main.js
+++ b/lib/main.js
@@ -26,6 +26,7 @@ const ResultCache = require('./result-cache');
 const ErrorMessage = require('./error-message');
 const SuppressedErrors = require('./suppressed-errors');
 const Watch = require('./watch');
+const exit = require('../vendor/exit');
 
 /**
  * @typedef { import("./types/options").Options } Options
@@ -57,7 +58,7 @@ function errorHandler(err) {
       : ErrorMessage.unexpectedError(err);
   console.log(ErrorMessage.report(options, errorToReport, reviewElmJsonPath));
 
-  process.exit(1);
+  exit(1);
 }
 
 async function runElmReview() {
@@ -141,7 +142,7 @@ You will need to run ${chalk.yellow(
     'elm-review prepare-offline'
   )} to keep the offline mode working
 if either your review configuration or your project's dependencies change.`);
-  process.exit(0);
+  exit(0);
 }
 
 module.exports = () => {

--- a/lib/options.js
+++ b/lib/options.js
@@ -9,6 +9,7 @@ const levenshtein = require('fastest-levenshtein');
 const packageJson = require('../package.json');
 const Flags = require('./flags');
 const ErrorMessage = require('./error-message');
+const exit = require('../vendor/exit');
 
 /**
  * @typedef { import("minimist").ParsedArgs } ParsedArgs
@@ -651,7 +652,7 @@ function reportErrorAndExit(errorToReport) {
   // @ts-expect-error - Handle this later
   console.log(ErrorMessage.report({}, errorToReport));
 
-  process.exit(1);
+  exit(1);
 }
 
 module.exports = {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,6 +12,7 @@ const SuppressedErrors = require('./suppressed-errors');
 const ReviewDependencies = require('./review-dependencies');
 const ProjectDependencies = require('./project-dependencies');
 const {runReview, startReview, requestReview} = require('./run-review');
+const exit = require('../vendor/exit');
 
 /**
  * @typedef { import("./types/options").Options } Options
@@ -123,7 +124,7 @@ async function initializeApp(options, elmModulePath, reviewElmJson, appHash) {
   });
   AppState.subscribe(app.ports.abortForConfigurationErrors, (errors) => {
     Report.report(options, {errors});
-    process.exit(1);
+    exit(1);
   });
 
   ModuleCache.subscribe(options, app);

--- a/lib/state.js
+++ b/lib/state.js
@@ -13,6 +13,7 @@
  */
 
 const Options = require('./options');
+const exit = require('../vendor/exit');
 
 /**
  * @type {Options}
@@ -86,7 +87,7 @@ function update(message) {
 
     case 'exitRequested': {
       if (model.filesBeingWrittenToCache.size === 0) {
-        process.exit(message.exitCode);
+        exit(message.exitCode);
       }
 
       model.exitRequest = {
@@ -108,7 +109,7 @@ function update(message) {
         model.filesBeingWrittenToCache.size === 0 &&
         model.exitRequest.requested
       ) {
-        process.exit(model.exitRequest.exitCode);
+        exit(model.exitRequest.exitCode);
       }
 
       return model;

--- a/lib/suppressed-errors.js
+++ b/lib/suppressed-errors.js
@@ -8,6 +8,7 @@ const chalk = require('chalk');
 const FS = require('./fs-wrapper');
 const OsHelpers = require('./os-helpers');
 const ErrorMessage = require('./error-message');
+const exit = require('../vendor/exit');
 
 /**
  * @typedef { import("./types/options").Options } Options
@@ -202,6 +203,6 @@ function checkForUncommittedSuppressions(options) {
 However, all tests have passed, so you don't need to run tests again after committing these changes.`
     );
 
-    process.exit(1);
+    exit(1);
   }
 }

--- a/vendor/exit.js
+++ b/vendor/exit.js
@@ -1,0 +1,41 @@
+/*
+ * exit
+ * https://github.com/cowboy/node-exit
+ *
+ * Copyright (c) 2013 "Cowboy" Ben Alman
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+module.exports = function exit(exitCode, streams) {
+  if (!streams) { streams = [process.stdout, process.stderr]; }
+  var drainCount = 0;
+  // Actually exit if all streams are drained.
+  function tryToExit() {
+    if (drainCount === streams.length) {
+      process.exit(exitCode);
+    }
+  }
+  streams.forEach(function(stream) {
+    // Count drained streams now, but monitor non-drained streams.
+    if (stream.bufferSize === 0) {
+      drainCount++;
+    } else {
+      stream.write('', 'utf-8', function() {
+        drainCount++;
+        tryToExit();
+      });
+    }
+    // Prevent further writing.
+    stream.write = function() {};
+  });
+  // If all streams were already drained, exit now.
+  tryToExit();
+  // In Windows, when run as a Node.js child process, a script utilizing
+  // this library might just exit with a 0 exit code, regardless. This code,
+  // despite the fact that it looks a bit crazy, appears to fix that.
+  process.on('exit', function() {
+    process.exit(exitCode);
+  });
+};

--- a/vendor/exit.js
+++ b/vendor/exit.js
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 /*
  * exit
  * https://github.com/cowboy/node-exit


### PR DESCRIPTION
This replaces all instances of `process.exit` with a new vendored dependency `exit` that drains all streams before exiting for real.

Fixes [the issue we talked about in the Elm slack](https://elmlang.slack.com/archives/C010RT4D1PT/p1714676525378159). For when that gets eaten by the Slack history monster, the problem is that `process.exit` would cut off JSON output when run from within a Node parent process.
