### PR TITLE
Add types to `report.js`

### DIFF
--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -214,12 +214,15 @@ function readAst(options, elmParserPath, source) {
  * @returns {Promise<Readme | null>}
  */
 async function getReadme(options, directoryContainingElmJson) {
-  return await FS.readFile(options.readmePath)
-    .then((content) => ({
+  try {
+    const content = await FS.readFile(options.readmePath);
+    return {
       path: path.relative(directoryContainingElmJson, options.readmePath),
       content
-    }))
-    .catch(() => null);
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/lib/report.js
+++ b/lib/report.js
@@ -5,12 +5,22 @@ module.exports = {
   report
 };
 
+/**
+ * @import { Options } from './types/options';
+ * @import { StyledMessage as StyledMsg } from './types/styled-message';
+ * @import { SuppressedErrorsFile } from './types/suppressed';
+ */
+
+/**
+ * @param {Options} options
+ * @param {{ errors?: { errors: unknown[]; path: unknown; }[] & StyledMsg; extracts?: unknown; suppressedErrors?: SuppressedErrorsFile[] }} result
+ */
 async function report(options, result) {
   Benchmark.start(options, 'Writing error report');
   if (options.report === 'json') {
     await print(options, result);
   } else {
-    StyledMessage.clearAndLog(options, result.errors, false);
+    StyledMessage.clearAndLog(options, result.errors ?? [], false);
   }
 
   Benchmark.end(options, 'Writing error report');
@@ -18,22 +28,30 @@ async function report(options, result) {
 
 // JSON
 
+/**
+ * @param {Options} options
+ * @param {{ errors?: { errors: unknown[]; path: unknown; }[]; extracts?: unknown; }} json
+ */
 function print(options, json) {
   if (options.reportOnOneLine) {
-    if (json.errors.length > 0) {
+    if ((json.errors?.length ?? 0) > 0) {
       return safeConsoleLog(
         json.errors
-          .map((errorForFile) => {
-            return errorForFile.errors
-              .map((error) => {
-                return JSON.stringify({
-                  path: errorForFile.path,
-                  ...error
-                });
-              })
-              .join('\n');
-          })
-          .join('\n')
+          ?.map(
+            (
+              /** @type {{ errors: unknown[]; path: unknown; }} */ errorForFile
+            ) => {
+              return errorForFile.errors
+                .map((error) => {
+                  return JSON.stringify({
+                    path: errorForFile.path,
+                    .../** @type {object} */ (error)
+                  });
+                })
+                .join('\n');
+            }
+          )
+          .join('\n') ?? ''
       );
     }
   } else {

--- a/lib/types/app.ts
+++ b/lib/types/app.ts
@@ -55,7 +55,9 @@ export type Ports = {
   fixConfirmationStatus: SubscribePort<unknown>;
   abort: SubscribePort<string>;
   abortWithDetails: SubscribePort<{title: string; message: string}>;
-  abortForConfigurationErrors: SubscribePort<unknown>;
+  abortForConfigurationErrors: SubscribePort<
+    {errors: unknown[]; path: unknown}[] & StyledMessage
+  >;
 };
 
 export type FileReceipt = {

--- a/tsconfig.no-implicit-any.json
+++ b/tsconfig.no-implicit-any.json
@@ -28,6 +28,7 @@
     "lib/path-helpers.js",
     "lib/project-json-files.js",
     "lib/promisify-port.js",
+    "lib/report.js",
     "lib/state.js",
     "lib/styled-message.js",
     "lib/suppressed-errors.js",


### PR DESCRIPTION
Depends on #177.
Here's the diff as GH doesn't play well with stacks from forks: <https://github.com/lishaduck/node-elm-review/compare/app-wrapper-types...report-types>