### PR TITLE
Enable `noImplicitAny` on `node-elm-compiler.js`

### DIFF
--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -195,7 +195,7 @@ function formatFileContent(options, file, filePath) {
   );
 
   if (result.error) {
-    if (result.error.code === 'ENOENT') {
+    if ('code' in result.error && result.error.code === 'ENOENT') {
       if (hasElmFormatPathFlag) {
         throw new ErrorMessage.CustomError(
           'ELM-FORMAT NOT FOUND',

--- a/lib/build.js
+++ b/lib/build.js
@@ -24,6 +24,7 @@ const exit = require('../vendor/exit');
  * @import {VersionString} from "./types/version"
  * @import {Options, Template} from "./types/options"
  * @import {Path} from "./types/path"
+ * @import {CompileOptions} from "../vendor/types/node-elm-compiler"
  */
 
 const templateSrc = path.join(__dirname, '../template/src');
@@ -362,26 +363,6 @@ function unique(array) {
   return [...new Set(array)];
 }
 
-// TODO: TSify
-/**
- * @typedef {object} CompileOptions
- * @property {string} cwd
- * @property {string} output
- * @property {boolean} debug
- * @property {boolean} optimize
- * @property {boolean} verbose
- * @property {boolean} warn
- * @property {'json' | undefined} report
- * @property {string} pathToElm
- * @property {ProcessOptions} processOpts
- */
-
-/**
- * @typedef {object} ProcessOptions
- * @property {NodeJS.ProcessEnv} env
- * @property {('ignore' | 'inherit' | 'pipe')[]} stdio
- */
-
 function compileElmProject(
   options,
   dest,
@@ -411,7 +392,7 @@ function compileElmProject(
 
     let stderr = '';
     if (compileProcess.stderr) {
-      compileProcess.stderr.on('data', (data) => {
+      compileProcess.stderr.on('data', (/** @type {string} */ data) => {
         stderr += data;
       });
     }

--- a/lib/elm-binary.js
+++ b/lib/elm-binary.js
@@ -57,6 +57,7 @@ A few options:
  */
 function getElmVersion(elmBinary) {
   const result = spawn.sync(elmBinary, ['--version'], {
+    // @ts-expect-error -- The types are outdated.
     silent: true,
     env: process.env
   });
@@ -78,6 +79,7 @@ function getElmVersion(elmBinary) {
 function downloadDependenciesOfElmJson(elmBinary, elmJsonPath) {
   const result = spawn.sync(elmBinary, ['make', '--report=json'], {
     cwd: path.dirname(elmJsonPath),
+    // @ts-expect-error -- The types are outdated.
     silent: false,
     env: process.env
   });

--- a/lib/options.js
+++ b/lib/options.js
@@ -229,7 +229,8 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
     localElmReviewSrc,
     forceBuild: args['force-build'] || Boolean(localElmReviewSrc),
     offline: args.offline,
-    report: args.report === 'json' || args.report === 'ndjson' ? 'json' : null,
+    report:
+      args.report === 'json' || args.report === 'ndjson' ? 'json' : undefined,
     reportOnOneLine: args.report === 'ndjson',
     rulesFilter: listOfStrings(args.rules),
     ignoredDirs: () =>

--- a/lib/types/options.ts
+++ b/lib/types/options.ts
@@ -71,7 +71,7 @@ export type ReviewOptions = Options & {
 
 export type DetailsMode = 'without-details' | 'with-details';
 
-export type ReportMode = 'json' | 'human' | null;
+export type ReportMode = 'json' | 'human' | undefined;
 
 export type NewPackagePrefilledAnswers = {
   authorName: string | undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
+        "@types/cross-spawn": "^6.0.6",
         "@types/folder-hash": "^4.0.4",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.5.2",
@@ -2005,6 +2006,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/folder-hash": {
       "version": "4.0.4",
@@ -13847,6 +13857,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/folder-hash": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
+    "@types/cross-spawn": "^6.0.6",
     "@types/folder-hash": "^4.0.4",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.5.2",

--- a/tsconfig.no-implicit-any.json
+++ b/tsconfig.no-implicit-any.json
@@ -33,6 +33,7 @@
     "lib/styled-message.js",
     "lib/suppressed-errors.js",
     "vendor/exit.js",
+    "vendor/node-elm-compiler.js",
     "jest.config.js"
   ]
 }

--- a/vendor/node-elm-compiler.js
+++ b/vendor/node-elm-compiler.js
@@ -1,10 +1,10 @@
 'use strict';
 
 /**
+ * @import {ChildProcess} from 'node:child_process'
  * @import {CompileOptions, ProcessOptions, Sources, Spawner} from './types/node-elm-compiler'
  */
 
-// @ts-ignore - I'm offline right now.
 var spawn = require('cross-spawn');
 var elmBinaryName = 'elm';
 
@@ -43,6 +43,7 @@ function prepareOptions(options, spawnFn) {
 /**
  * @param {Sources} sources
  * @param {CompileOptions} options
+ * @returns {string[]}
  */
 function prepareProcessArgs(sources, options) {
   var preparedSources = prepareSources(sources);
@@ -69,7 +70,7 @@ function prepareProcessOpts(options) {
  * @param {Sources} sources
  * @param {CompileOptions} options
  * @param {string} pathToElm
- * @returns {NodeJS.Process}
+ * @returns {ChildProcess}
  */
 function runCompiler(sources, options, pathToElm) {
   if (typeof options.spawn !== 'function') {
@@ -87,6 +88,7 @@ function runCompiler(sources, options, pathToElm) {
     console.log(['Running', pathToElm].concat(processArgs).join(' '));
   }
 
+  // @ts-expect-error -- processArgs is `string[]`, but spawn expects `SpawnOptions`.
   return options.spawn(pathToElm, processArgs, processOpts);
 }
 

--- a/vendor/types/node-elm-compiler.ts
+++ b/vendor/types/node-elm-compiler.ts
@@ -1,4 +1,4 @@
-import type {MessagePort} from 'worker_threads';
+import type {ChildProcess, SpawnOptions} from 'node:child_process';
 import type {ReportMode} from '../../lib/types/options';
 
 export type CompileOptions = {
@@ -24,8 +24,8 @@ export interface ProcessOptions {
 
 export type Spawner = (
   pathToElm: string,
-  processArgs: string[],
+  processArgs: SpawnOptions,
   processOpts: ProcessOptions
-) => NodeJS.Process;
+) => ChildProcess;
 
 export type Sources = string | string[];

--- a/vendor/types/node-elm-compiler.ts
+++ b/vendor/types/node-elm-compiler.ts
@@ -1,0 +1,31 @@
+import type {MessagePort} from 'worker_threads';
+import type {ReportMode} from '../../lib/types/options';
+
+export type CompileOptions = {
+  spawn?: Spawner;
+
+  cwd: string;
+  output: string;
+  debug: boolean;
+  optimize: boolean;
+  verbose: boolean;
+  warn: boolean;
+  report: ReportMode;
+  pathToElm: string;
+  help?: undefined;
+  docs?: undefined;
+  processOpts: ProcessOptions;
+};
+
+export interface ProcessOptions {
+  env: NodeJS.ProcessEnv;
+  stdio: ('ignore' | 'inherit' | 'pipe')[];
+}
+
+export type Spawner = (
+  pathToElm: string,
+  processArgs: string[],
+  processOpts: ProcessOptions
+) => NodeJS.Process;
+
+export type Sources = string | string[];


### PR DESCRIPTION
Part 2 of 2.

_**Depends on:** #187_
_**Relates**: #125_
Here's the diff as GH doesn't play well with stacks from forks: <https://github.com/lishaduck/node-elm-review/compare/ts-check...node-elm-compiler-no-implict-any>
