### PR TITLE
Enable `noImplicitAny` on `result-cache-json.js`

### DIFF
--- a/lib/fs-wrapper.js
+++ b/lib/fs-wrapper.js
@@ -4,13 +4,14 @@ const {rimraf} = require('rimraf');
 
 /**
  * @import {Path} from "./types/path"
+ * @import {Replacer, Reviver} from "./types/json"
  */
 
 /**
  * Read a JSON file.
  *
  * @param {string} file
- * @param {((key: string, value: unknown) => unknown) | undefined} [reviver=undefined]
+ * @param {Reviver | undefined} [reviver=undefined]
  * @returns {Promise<unknown>}
  */
 async function readJsonFile(file, reviver) {
@@ -54,7 +55,7 @@ async function readFile(file, options) {
  * @param {string} file
  * @param {object} content
  * @param {string | number | undefined} [space=undefined]
- * @param {((key: string, value: unknown) => unknown) | undefined} [replacer=undefined]
+ * @param {Replacer | undefined} [replacer=undefined]
  * @returns {Promise<void>}
  */
 async function writeJson(file, content, space, replacer) {

--- a/lib/result-cache-json.js
+++ b/lib/result-cache-json.js
@@ -3,7 +3,15 @@ module.exports = {
   reviver
 };
 
-function replacer(_key, value) {
+/**
+ * @import {Replacer, Reviver} from "./types/json"
+ * @import {Value, ValueStruct} from "./types/elm-internals"
+ */
+
+/** @type {Replacer} */
+function replacer(_key, value_) {
+  const value = /** @type {Value} */ (value_);
+
   if (value === null) {
     return value;
   }
@@ -16,6 +24,7 @@ function replacer(_key, value) {
     //     a: toDictProd(value, {})
     //   };
     // }
+
     if (
       value.$ === 1 &&
       value.a !== undefined &&
@@ -51,6 +60,9 @@ function replacer(_key, value) {
   return '$$elm-review$$+Inf';
 }
 
+/**
+ * @param {ValueStruct} xs
+ */
 function prudentListToArray(xs) {
   const out = [];
   for (; xs.b; xs = xs.b) {
@@ -68,17 +80,18 @@ function prudentListToArray(xs) {
   return out;
 }
 
-function reviver(_, value) {
-  const type_ = typeof value;
-  if (type_ === 'object' && value.$ === '$L') {
-    return _ListFromArrayPROD(value.a);
-  }
+/** @type {Reviver} */
+function reviver(_, value_) {
+  const value = /** @type {Value} */ (value_);
 
   if (
-    type_ !== 'string' ||
-    value === null ||
-    !value.startsWith('$$elm-review$$')
+    typeof value === 'object' &&
+    /** @type {SomethingObject} */ value?.$ === '$L'
   ) {
+    return _ListFromArrayPROD(/** @type {string | string[]} */ (value.a));
+  }
+
+  if (typeof value !== 'string' || !value?.startsWith('$$elm-review$$')) {
     return value;
   }
 
@@ -101,8 +114,13 @@ function reviver(_, value) {
   }
 }
 
-const _ListNilPROD = {$: 0};
+const _ListNilPROD = /** @type {const} */ ({$: 0});
+
+/**
+ * @param {string | string[]} array
+ */
 function _ListFromArrayPROD(array) {
+  /** @type {ValueStruct} */
   let out = _ListNilPROD;
   for (let i = array.length; i--; ) {
     out = {$: 1, a: array[i], b: out};

--- a/lib/types/elm-internals.ts
+++ b/lib/types/elm-internals.ts
@@ -1,0 +1,7 @@
+export type Value = null | ValueStruct | number | string;
+export type ValueStruct = {
+  $: 1 | -1 | 0 | `$L`;
+  a?: string[] | string;
+  b?: ValueStruct;
+  c?: unknown;
+};

--- a/lib/types/json.ts
+++ b/lib/types/json.ts
@@ -1,0 +1,9 @@
+/**
+ * A replacer function for JSON.stringify.
+ */
+export type Replacer = (key: string, value: unknown) => unknown;
+
+/**
+ * A reviver function for JSON.parse.
+ */
+export type Reviver = (key: string, value: unknown) => unknown;

--- a/tsconfig.no-implicit-any.json
+++ b/tsconfig.no-implicit-any.json
@@ -29,6 +29,7 @@
     "lib/project-json-files.js",
     "lib/promisify-port.js",
     "lib/report.js",
+    "lib/result-cache-json.js",
     "lib/state.js",
     "lib/styled-message.js",
     "lib/suppressed-errors.js",


### PR DESCRIPTION
_**Depends on:** #188_
_**Relates**: #125_
Here's the diff as GH doesn't play well with stacks from forks: <https://github.com/lishaduck/node-elm-review/compare/node-elm-compiler-no-implict-any...result-cache-json-no-implict-any>
