### PR TITLE
Improve shell scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ name: CI
 
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ ElmjutsuDumMyM0DuL3.elm
 .vscode/
 
 .turbo
+.envrc

--- a/test/run.sh
+++ b/test/run.sh
@@ -215,7 +215,7 @@ $createTest "$CMD" \
 
 if [ "$1" != "record" ]
 then
-    if [ "$(diff -yq "$TMP/project to fix/src/Main.elm" "$SNAPSHOTS/project to fix/src/Main.elm")" != "" ]
+    if [ "$(diff -q "$TMP/project to fix/src/Main.elm" "$SNAPSHOTS/project to fix/src/Main.elm")" != "" ]
     then
         echo -e "Running with --fix-all-without-prompt (looking at code)"
         echo -e "\x1B[31m  ERROR\n  I found a different FIX output  for Main.elmthan expected:\x1B[0m"
@@ -223,7 +223,7 @@ then
         diff -py "$TMP/project to fix/src/Main.elm" "$SNAPSHOTS/project to fix/src/Main.elm"
         exit 1
     fi
-    if [ "$(diff -yq "$TMP/project to fix/src/Folder/Used.elm" "$SNAPSHOTS/project to fix/src/Folder/Used.elm")" != "" ]
+    if [ "$(diff -q "$TMP/project to fix/src/Folder/Used.elm" "$SNAPSHOTS/project to fix/src/Folder/Used.elm")" != "" ]
     then
         echo -e "Running with --fix-all-without-prompt (looking at code)"
         echo -e "\x1B[31m  ERROR\n  I found a different FIX output than expected for Folder/Used.elm:\x1B[0m"
@@ -231,7 +231,7 @@ then
         diff -py "$TMP/project to fix/src/Folder/Used.elm" "$SNAPSHOTS/project to fix/src/Folder/Used.elm"
         exit 1
     fi
-    if [ "$(diff -yq "$TMP/project to fix/src/Folder/Unused.elm" "$SNAPSHOTS/project to fix/src/Folder/Unused.elm")" != "" ]
+    if [ "$(diff -q "$TMP/project to fix/src/Folder/Unused.elm" "$SNAPSHOTS/project to fix/src/Folder/Unused.elm")" != "" ]
     then
         echo -e "Running with --fix-all-without-prompt (looking at code)"
         echo -e "\x1B[31m  ERROR\n  I found a different FIX output than expected for Folder/Unused.elm:\x1B[0m"

--- a/test/run.sh
+++ b/test/run.sh
@@ -37,7 +37,9 @@ function runCommandAndCompareToSnapshot {
     (eval "$LOCAL_COMMAND$AUTH --FOR-TESTS $ARGS" || true) 2>&1 \
         | $REPLACE_SCRIPT \
         > "$TMP/$FILE"
-    if [ "$(diff "$TMP/$FILE" "$SNAPSHOTS/$FILE")" != "" ]
+    local diffed
+    diffed="$(diff "$TMP/$FILE" "$SNAPSHOTS/$FILE" || true)"
+    if [ "$diffed" != "" ]
     then
         echo -e "\x1B[31m  ERROR\n  I found a different output than expected:\x1B[0m"
         echo -e "\n    \x1B[31mExpected:\x1B[0m\n"
@@ -46,7 +48,6 @@ function runCommandAndCompareToSnapshot {
         cat "$TMP/$FILE"
         echo -e "\n    \x1B[31mHere is the difference:\x1B[0m\n"
         diff -p "$TMP/$FILE" "$SNAPSHOTS/$FILE"
-        exit 1
     else
       echo -e "  \x1B[92mOK\x1B[0m"
     fi
@@ -115,11 +116,13 @@ function checkFolderContents {
   if [ "$SUBCOMMAND" != "record" ]
   then
     echo -n "  Checking generated files are the same"
-    if [ "$(diff -rq "$TMP/$1/" "$SNAPSHOTS/$1/" --exclude="elm-stuff")" != "" ]
+
+    local diffed
+    diffed="$(diff -rq "$TMP/$1/" "$SNAPSHOTS/$1/" --exclude="elm-stuff" || true)"
+    if [ "$diffed" != "" ]
     then
         echo -e "\x1B[31m  ERROR\n  The generated files are different:\x1B[0m"
         diff -rq "$TMP/$1/" "$SNAPSHOTS/$1/" --exclude="elm-stuff"
-        exit 1
     else
       echo -e "  \x1B[92mOK\x1B[0m"
     fi
@@ -215,29 +218,32 @@ $createTest "$CMD" \
 
 if [ "$SUBCOMMAND" != "record" ]
 then
-    if [ "$(diff -q "$TMP/project to fix/src/Main.elm" "$SNAPSHOTS/project to fix/src/Main.elm")" != "" ]
+    declare diffed
+    diffed="$(diff -q "$TMP/project to fix/src/Main.elm" "$SNAPSHOTS/project to fix/src/Main.elm" || true)"
+    if [ "$diffed" != "" ]
     then
         echo -e "Running with --fix-all-without-prompt (looking at code)"
         echo -e "\x1B[31m  ERROR\n  I found a different FIX output  for Main.elmthan expected:\x1B[0m"
         echo -e "\n    \x1B[31mHere is the difference:\x1B[0m\n"
         diff -py "$TMP/project to fix/src/Main.elm" "$SNAPSHOTS/project to fix/src/Main.elm"
-        exit 1
     fi
-    if [ "$(diff -q "$TMP/project to fix/src/Folder/Used.elm" "$SNAPSHOTS/project to fix/src/Folder/Used.elm")" != "" ]
+    declare diffed
+    diffed="$(diff -q "$TMP/project to fix/src/Folder/Used.elm" "$SNAPSHOTS/project to fix/src/Folder/Used.elm" || true)"
+    if [ "$diffed" != "" ]
     then
         echo -e "Running with --fix-all-without-prompt (looking at code)"
         echo -e "\x1B[31m  ERROR\n  I found a different FIX output than expected for Folder/Used.elm:\x1B[0m"
         echo -e "\n    \x1B[31mHere is the difference:\x1B[0m\n"
         diff -py "$TMP/project to fix/src/Folder/Used.elm" "$SNAPSHOTS/project to fix/src/Folder/Used.elm"
-        exit 1
     fi
-    if [ "$(diff -q "$TMP/project to fix/src/Folder/Unused.elm" "$SNAPSHOTS/project to fix/src/Folder/Unused.elm")" != "" ]
+    declare diffed
+    diffed="$(diff -q "$TMP/project to fix/src/Folder/Unused.elm" "$SNAPSHOTS/project to fix/src/Folder/Unused.elm" || true)"
+    if [ "$diffed" != "" ]
     then
         echo -e "Running with --fix-all-without-prompt (looking at code)"
         echo -e "\x1B[31m  ERROR\n  I found a different FIX output than expected for Folder/Unused.elm:\x1B[0m"
         echo -e "\n    \x1B[31mHere is the difference:\x1B[0m\n"
         diff -py "$TMP/project to fix/src/Folder/Unused.elm" "$SNAPSHOTS/project to fix/src/Folder/Unused.elm"
-        exit 1
     fi
 fi
 
@@ -254,7 +260,7 @@ $createTest "$CMD" \
     "Fixing all errors for an entire rule should remove the suppression file" \
     "" \
     "suppressed-errors-after-fixed-errors-for-rule.txt"
-if [ -f review/suppressed/NoUnused.Dependencies.json ]; then
+if [ -f "./review/suppressed/NoUnused.Dependencies.json" ]; then
     echo "Expected project-with-suppressed-errors/review/suppressed/NoUnused.Dependencies.json to have been deleted"
     exit 1
 fi
@@ -267,7 +273,9 @@ $createTest "$CMD" \
     "" \
     "suppressed-errors-after-fixed-errors-for-file.txt"
 
-if [ "$(diff review/suppressed/NoUnused.Variables.json expected-NoUnused.Variables.json)" != "" ]; then
+declare diffed
+diffed="$(diff review/suppressed/NoUnused.Variables.json expected-NoUnused.Variables.json || true)"
+if [ "$diffed" != "" ]; then
     echo "Expected project-with-suppressed-errors/review/suppressed/NoUnused.Variables.json to have been updated"
     exit 1
 fi

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 CWD=$(pwd)
 CMD="elm-review --no-color"
@@ -34,7 +34,7 @@ function runCommandAndCompareToSnapshot {
       exit 1
     fi
 
-    eval "$LOCAL_COMMAND$AUTH --FOR-TESTS $ARGS" 2>&1 \
+    (eval "$LOCAL_COMMAND$AUTH --FOR-TESTS $ARGS" || true) 2>&1 \
         | $REPLACE_SCRIPT \
         > "$TMP/$FILE"
     if [ "$(diff "$TMP/$FILE" "$SNAPSHOTS/$FILE")" != "" ]

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-set -eo pipefail
+set -euo pipefail
 
 CWD=$(pwd)
 CMD="elm-review --no-color"
 TMP="$CWD/temporary"
 ELM_HOME="$TMP/elm-home"
 SNAPSHOTS="$CWD/run-snapshots"
-SUBCOMMAND="$1"
+SUBCOMMAND="${1:-}"
 REPLACE_SCRIPT="node $CWD/replace-local-path.js"
 
 # If you get errors like rate limit exceeded, you can run these tests
 # with "GITHUB_AUTH=gitHubUserName:token"
 # Follow this guide: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
 # to create an API token, and give it access to public repositories.
-if [ -z "${GITHUB_AUTH}" ]
+if [ -z "${GITHUB_AUTH:-}" ]
 then
   AUTH=""
 else
@@ -153,7 +153,7 @@ rm -rf "$TMP" \
 
 mkdir -p "$TMP"
 
-if [ "$1" == "record" ]
+if [ "$SUBCOMMAND" == "record" ]
 then
   createTest=runAndRecord
   rm -rf "$SNAPSHOTS" &> /dev/null
@@ -197,7 +197,7 @@ checkFolderContents $INIT_TEMPLATE_PROJECT_NAME
 
 # FIXES
 
-if [ "$1" == "record" ]
+if [ "$SUBCOMMAND" == "record" ]
 then
   rm -rf "$SNAPSHOTS/project to fix"
   cp -r "$CWD/project-with-errors" "$SNAPSHOTS/project to fix"
@@ -213,7 +213,7 @@ $createTest "$CMD" \
     "--fix-all-without-prompt" \
     "fix-all.txt"
 
-if [ "$1" != "record" ]
+if [ "$SUBCOMMAND" != "record" ]
 then
     if [ "$(diff -q "$TMP/project to fix/src/Main.elm" "$SNAPSHOTS/project to fix/src/Main.elm")" != "" ]
     then
@@ -284,7 +284,7 @@ cd "$CWD"
 
 # new-package
 
-if [ "$1" == "record" ]
+if [ "$SUBCOMMAND" == "record" ]
 then
   cd "$SNAPSHOTS/"
 else


### PR DESCRIPTION
I'm going to run our testing scripts through [OSH](https://www.oilshell.org/cross-ref.html?tag=OSH#OSH), see what antipatterns it spots, and fix the warnings.
OSH is a fast, simple, (almost) 100% bash-compatible and POSIX-compliant shell from the Oils project. It supports some extra `shopt`s, which catch things bash and shellcheck don't/can't (respectively). It also supports some `shopt`s that make breaking changes (ysh), but I don't plan on making our tests non-compatible with bash (as that would break CI, for one reason).