### PR TITLE
chore: enable `noImplicitAny` on `dependency-provider.js`

### DIFF
--- a/lib/dependency-provider.js
+++ b/lib/dependency-provider.js
@@ -48,7 +48,7 @@ class DependencyProvider {
         extra,
         (pkg, version) =>
           fetchElmJsonOffline(options, elmVersion, pkg, version),
-        (/** @type {string} */ pkg) => lister.list(elmVersion, pkg)
+        (pkg) => lister.list(elmVersion, pkg)
       );
     } catch (error) {
       throw new Error(error);
@@ -282,6 +282,7 @@ class OnlineAvailableVersionLister {
  */
 function readVersionsInElmHomeAndSort(elmVersion, pkg) {
   const pkgPath = ProjectJsonFiles.getPackagePathInElmHome(elmVersion, pkg);
+  /** @type {string[]} */
   let offlineVersions;
   try {
     offlineVersions = fs.readdirSync(pkgPath);

--- a/lib/project-json-files.js
+++ b/lib/project-json-files.js
@@ -32,7 +32,6 @@ async function getElmJson(options, elmVersion, name, packageVersion) {
     return await getElmJsonFromElmHome(elmVersion, name, packageVersion);
   } catch {
     // Then in the dependency cache for elm-review
-
     const cacheLocation = elmReviewDependencyCache(
       options,
       elmVersion,

--- a/lib/template-dependencies.js
+++ b/lib/template-dependencies.js
@@ -261,7 +261,7 @@ function filterOutDuplicateDependenciesForSection(
 ) {
   return Object.fromEntries(
     Object.entries(testDependencies).filter(
-      ([pkg, _]) => !regularDependencies[pkg]
+      ([pkg]) => !regularDependencies[pkg]
     )
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "^4.0.0",
         "chokidar": "^3.5.2",
         "cross-spawn": "^7.0.3",
-        "elm-solve-deps-wasm": "^1.0.2",
+        "elm-solve-deps-wasm": "^1.0.2 || ^2.0.0",
         "fastest-levenshtein": "^1.0.16",
         "find-up": "^4.1.0",
         "folder-hash": "^3.3.0",
@@ -3904,9 +3904,9 @@
       "dev": true
     },
     "node_modules/elm-solve-deps-wasm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/elm-solve-deps-wasm/-/elm-solve-deps-wasm-1.0.2.tgz",
-      "integrity": "sha512-qnwo7RO9IO7jd9SLHvIy0rSOEIlc/tNMTE9Cras0kl+b161PVidW4FvXo0MtXU8GAKi/2s/HYvhcnpR/NNQ1zw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/elm-solve-deps-wasm/-/elm-solve-deps-wasm-2.0.0.tgz",
+      "integrity": "sha512-11OV8FgB9qsth/F94q2SJjb1MoEgbworSyNM1L+YlxVoaxp7wtWPyA8cNcPEkSoIKG1B8Tqg68ED1P6dVamHSg=="
     },
     "node_modules/elm-test": {
       "version": "0.19.1-revision12",
@@ -3949,6 +3949,12 @@
       "engines": {
         "node": "^12.20.0 || >=14"
       }
+    },
+    "node_modules/elm-test/node_modules/elm-solve-deps-wasm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/elm-solve-deps-wasm/-/elm-solve-deps-wasm-1.0.2.tgz",
+      "integrity": "sha512-qnwo7RO9IO7jd9SLHvIy0rSOEIlc/tNMTE9Cras0kl+b161PVidW4FvXo0MtXU8GAKi/2s/HYvhcnpR/NNQ1zw==",
+      "dev": true
     },
     "node_modules/elm-test/node_modules/glob": {
       "version": "8.0.3",
@@ -15257,9 +15263,9 @@
       "dev": true
     },
     "elm-solve-deps-wasm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/elm-solve-deps-wasm/-/elm-solve-deps-wasm-1.0.2.tgz",
-      "integrity": "sha512-qnwo7RO9IO7jd9SLHvIy0rSOEIlc/tNMTE9Cras0kl+b161PVidW4FvXo0MtXU8GAKi/2s/HYvhcnpR/NNQ1zw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/elm-solve-deps-wasm/-/elm-solve-deps-wasm-2.0.0.tgz",
+      "integrity": "sha512-11OV8FgB9qsth/F94q2SJjb1MoEgbworSyNM1L+YlxVoaxp7wtWPyA8cNcPEkSoIKG1B8Tqg68ED1P6dVamHSg=="
     },
     "elm-test": {
       "version": "0.19.1-revision12",
@@ -15292,6 +15298,12 @@
           "version": "9.4.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
           "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+          "dev": true
+        },
+        "elm-solve-deps-wasm": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/elm-solve-deps-wasm/-/elm-solve-deps-wasm-1.0.2.tgz",
+          "integrity": "sha512-qnwo7RO9IO7jd9SLHvIy0rSOEIlc/tNMTE9Cras0kl+b161PVidW4FvXo0MtXU8GAKi/2s/HYvhcnpR/NNQ1zw==",
           "dev": true
         },
         "glob": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "chalk": "^4.0.0",
     "chokidar": "^3.5.2",
     "cross-spawn": "^7.0.3",
-    "elm-solve-deps-wasm": "^1.0.2",
+    "elm-solve-deps-wasm": "^1.0.2 || ^2.0.0",
     "fastest-levenshtein": "^1.0.16",
     "find-up": "^4.1.0",
     "folder-hash": "^3.3.0",

--- a/tsconfig.no-implicit-any.json
+++ b/tsconfig.no-implicit-any.json
@@ -8,6 +8,7 @@
     "lib/benchmark.js",
     "lib/cache.js",
     "lib/debug.js",
+    "lib/dependency-provider.js",
     "lib/elm-communication.js",
     "lib/elm-files.js",
     "lib/extra-files.js",


### PR DESCRIPTION
This is ready to be merged, except for the part where I add a github dependency.

_**Blocked by:** mpizenberg/elm-solve-deps-wasm#3._
_**Depends on:** #191._
_**Relates to:** #125._
Here's the diff, as GH doesn't play well with stacks from forks: <https://github.com/lishaduck/node-elm-review/compare/result-cache-json-no-implict-any...dependency-provider-no-implict-any>