### PR TITLE
Update engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   },
   "packageManager": "npm@8.19.4",
   "engines": {
-    "node": ">=14.18"
+    "node": ">=16 || 14 >=14.18"
   },
   "enginesStrict": true
 }


### PR DESCRIPTION
This is our actual bare minimum Node.js version right now.
I'd forgotten to exclude versions without Node.js 16 backports (i.e., Node.js 15).

Extracted from #190.