### PR TITLE
Reduce Dependabot cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directories: # Location of package manifests
       - '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     groups:
       chalk:
         patterns:
@@ -30,7 +30,7 @@ updates:
       - '/' # Strangely, this is how to specify "./.github/workflows/*.ya?ml"
       - '/new-package'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     groups:
       github-actions:
         patterns:
@@ -43,7 +43,7 @@ updates:
       - 'review'
       - 'template'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     groups:
       elm:
         patterns:


### PR DESCRIPTION
#186 lead to, say, quite a few updates. Given how frequently some packages release, I figure it's better to go ahead and reduce the cadence. A one-hour rate-limit overload a week sounds better than one every day.