### PR TITLE
Fix colors not showing up

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -423,7 +423,7 @@ function compileElmProject(
           )
         );
         compileOptions.processOpts.stdio = ['ignore', 'ignore', 'inherit'];
-        compileOptions.report = undefined;
+        compileOptions.report = null;
         const compileProcessToGetColoredErrors = elmCompiler.compile(
           compileTargets,
           compileOptions

--- a/lib/options.js
+++ b/lib/options.js
@@ -229,8 +229,7 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
     localElmReviewSrc,
     forceBuild: args['force-build'] || Boolean(localElmReviewSrc),
     offline: args.offline,
-    report:
-      args.report === 'json' || args.report === 'ndjson' ? 'json' : undefined,
+    report: args.report === 'json' || args.report === 'ndjson' ? 'json' : null,
     reportOnOneLine: args.report === 'ndjson',
     rulesFilter: listOfStrings(args.rules),
     ignoredDirs: () =>

--- a/lib/types/options.ts
+++ b/lib/types/options.ts
@@ -71,7 +71,7 @@ export type ReviewOptions = Options & {
 
 export type DetailsMode = 'without-details' | 'with-details';
 
-export type ReportMode = 'json' | 'human' | undefined;
+export type ReportMode = 'json' | 'human' | null;
 
 export type NewPackagePrefilledAnswers = {
   authorName: string | undefined;

--- a/vendor/node-elm-compiler.js
+++ b/vendor/node-elm-compiler.js
@@ -195,12 +195,7 @@ function compilerArgsFromOptions(options) {
           case 'optimize':
             return ['--optimize'];
           case 'runtimeOptions':
-            return [
-              '+RTS',
-              // @ts-expect-error(TS2488): TS doesn't get what we're doing here.
-              ...value,
-              '-RTS'
-            ];
+            return ['+RTS', ...value, '-RTS'];
           default:
             throw new Error(
               'node-elm-compiler was given an unrecognized Elm compiler option: ' +


### PR DESCRIPTION
Colors were not showing up anymore when you running a plain `elm-review`.
It seems it was broken in 69ac731 when turning the report into `undefined`, though I'm not entirely sure how that's related :thinking: 

cc @lishaduck 