### PR TITLE
Boost dependabot's signal-to-noise ratio significantly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,22 @@ updates:
           - 'turbo'
           - 'eslint-config-turbo'
           - 'eslint-plugin-turbo'
+    ignore:
+      - dependency-name: '@typescript-eslint/*'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'fs-extra'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'chalk'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'strip-ansi'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'wrap-ansi'
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: 'github-actions' # See documentation for possible values
     directories: # Location of package manifests
       - '/' # Strangely, this is how to specify "./.github/workflows/*.ya?ml"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,12 +39,23 @@ updates:
     directories: # Location of package manifests
       - '/ast-codec'
       - '/new-package/review-config-templates/2.3.0'
-      - 'parseElm'
-      - 'review'
-      - 'template'
+      - '/parseElm'
+      - '/review'
+      - '/template'
+      - '/test/config-*/'
+      - '/test/project-*/'
     schedule:
       interval: 'weekly'
     groups:
       elm:
         patterns:
           - 'elm/*'
+      jfmengels/elm-review:
+        patterns:
+          - 'jfmengels/elm-review'
+      jfmengels/elm-review-rules:
+        patterns:
+          - 'jfmengels/elm-review-*'
+      stil4m/elm-syntax:
+        patterns:
+          - 'stil4m/elm-syntax'


### PR DESCRIPTION
Group a whole bunch of elm dependency bumps across the tree. Also automate updating the test snapshots as well. Previously, I hadn't really grouped elm dependency bumps, and they still needed to be accompanied with a manual update of the test snapshots.

@jfmengels, I think this'll help a lot. Probably merge #256 first though, as otherwise this'll make dependabot recreate a bunch of prs. 