### PR TITLE
Remove unused MartinSStewart/elm-serialize dependency

### DIFF
--- a/ast-codec/elm.json
+++ b/ast-codec/elm.json
@@ -6,17 +6,12 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "MartinSStewart/elm-serialize": "1.3.1",
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "stil4m/elm-syntax": "7.3.6"
         },
         "indirect": {
-            "bburdette/toop": "1.2.0",
-            "danfishgold/base64-bytes": "1.1.0",
-            "elm/bytes": "1.0.8",
             "elm/parser": "1.1.0",
-            "elm/regex": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }


### PR DESCRIPTION
This package is in practice vendored as `Elm.Review.Vendor.Serialize`.

Supersedes https://github.com/jfmengels/node-elm-review/pull/200