### PR TITLE
New elm-syntax

### DIFF
--- a/ast-codec/elm.json
+++ b/ast-codec/elm.json
@@ -8,7 +8,7 @@
         "direct": {
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/parser": "1.1.0",

--- a/new-package/review-config-templates/2.3.0/elm.json
+++ b/new-package/review-config-templates/2.3.0/elm.json
@@ -18,7 +18,7 @@
             "jfmengels/elm-review-simplify": "2.1.5",
             "jfmengels/elm-review-unused": "1.2.3",
             "sparksp/elm-review-forbidden-words": "1.0.1",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/parseElm/elm.json
+++ b/parseElm/elm.json
@@ -9,7 +9,7 @@
         "direct": {
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/parser": "1.1.0",

--- a/review/elm.json
+++ b/review/elm.json
@@ -17,7 +17,7 @@
             "jfmengels/elm-review-documentation": "2.0.4",
             "jfmengels/elm-review-simplify": "2.1.5",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/template/elm.json
+++ b/template/elm.json
@@ -12,7 +12,7 @@
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/config-configuration-error/elm.json
+++ b/test/config-configuration-error/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/config-empty/elm.json
+++ b/test/config-empty/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/config-error-debug/elm.json
+++ b/test/config-error-debug/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/config-error-unknown-module/elm.json
+++ b/test/config-error-unknown-module/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/config-for-outdated-elm-review-version/elm.json
+++ b/test/config-for-outdated-elm-review-version/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "1.0.0",
             "jfmengels/review-unused": "1.0.4",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/html": "1.0.0",

--- a/test/config-for-salvageable-elm-review-version/elm.json
+++ b/test/config-for-salvageable-elm-review-version/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/review-unused": "2.1.5",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/config-syntax-error/elm.json
+++ b/test/config-syntax-error/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/config-that-triggers-no-errors/elm.json
+++ b/test/config-that-triggers-no-errors/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/config-without-elm-review/elm.json
+++ b/test/config-without-elm-review/elm.json
@@ -10,7 +10,7 @@
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/project-using-es2015-module/review/elm.json
+++ b/test/project-using-es2015-module/review/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/project-with-errors/review/elm.json
+++ b/test/project-with-errors/review/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/project-with-suppressed-errors-no-write/review/elm.json
+++ b/test/project-with-suppressed-errors-no-write/review/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/project-with-suppressed-errors/review/elm.json
+++ b/test/project-with-suppressed-errors/review/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/project-with-suppressed-errors2/review/elm.json
+++ b/test/project-with-suppressed-errors2/review/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/project-with-unsupported-suppression-version/review/elm.json
+++ b/test/project-with-unsupported-suppression-version/review/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/run-snapshots/elm-review-something-for-new-rule/preview/elm.json
+++ b/test/run-snapshots/elm-review-something-for-new-rule/preview/elm.json
@@ -9,7 +9,7 @@
         "direct": {
             "elm/core": "1.0.5",
             "jfmengels/elm-review": "2.14.1",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/run-snapshots/elm-review-something-for-new-rule/review/elm.json
+++ b/test/run-snapshots/elm-review-something-for-new-rule/review/elm.json
@@ -18,7 +18,7 @@
             "jfmengels/elm-review-simplify": "2.1.5",
             "jfmengels/elm-review-unused": "1.2.3",
             "sparksp/elm-review-forbidden-words": "1.0.1",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/run-snapshots/elm-review-something/preview/elm.json
+++ b/test/run-snapshots/elm-review-something/preview/elm.json
@@ -9,7 +9,7 @@
         "direct": {
             "elm/core": "1.0.5",
             "jfmengels/elm-review": "2.14.1",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/run-snapshots/elm-review-something/review/elm.json
+++ b/test/run-snapshots/elm-review-something/review/elm.json
@@ -18,7 +18,7 @@
             "jfmengels/elm-review-simplify": "2.1.5",
             "jfmengels/elm-review-unused": "1.2.3",
             "sparksp/elm-review-forbidden-words": "1.0.1",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/run-snapshots/init-project/review/elm.json
+++ b/test/run-snapshots/init-project/review/elm.json
@@ -8,7 +8,7 @@
         "direct": {
             "elm/core": "1.0.5",
             "jfmengels/elm-review": "2.14.1",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/run-snapshots/init-template-project/review/elm.json
+++ b/test/run-snapshots/init-template-project/review/elm.json
@@ -10,7 +10,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/test/run-snapshots/project to fix/review/elm.json
+++ b/test/run-snapshots/project to fix/review/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.14.1",
             "jfmengels/elm-review-unused": "1.2.3",
-            "stil4m/elm-syntax": "7.3.6"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/bytes": "1.0.8",


### PR DESCRIPTION
Bumps elm-syntax

---

For reference, this invocation's worked for me the last few times I needed to do this: `fd --ignore --type f elm.json . --exec npx elm-json upgrade --yes`.
The only issue is that, for some reason, most (but not all) of the snapshots strip the trailing newline from the `elm.json` file.