### PR TITLE
Fix error for unparsable configuration

### DIFF
--- a/test/run-snapshots/remote-configuration-with-unparsable-elmjson-json.txt
+++ b/test/run-snapshots/remote-configuration-with-unparsable-elmjson-json.txt
@@ -3,6 +3,6 @@
   "title": "TEMPLATE ELM.JSON PARSING ERROR",
   "path": "<local-path>/test/project-with-errors/review/elm.json",
   "message": [
-    "I found the elm.json associated with jfmengels/node-elm-review repository on GitHub,\nbut I encountered a problem when parsing it:\n\nUnexpected token / in JSON at position 137"
+    "I found the elm.json associated with jfmengels/node-elm-review repository on GitHub,\nbut I encountered a problem when parsing it:\n\nUnexpected token / in JSON at position 135"
   ]
 }

--- a/test/run-snapshots/remote-configuration-with-unparsable-elmjson-ndjson.txt
+++ b/test/run-snapshots/remote-configuration-with-unparsable-elmjson-ndjson.txt
@@ -3,6 +3,6 @@
   "title": "TEMPLATE ELM.JSON PARSING ERROR",
   "path": "<local-path>/test/project-with-errors/review/elm.json",
   "message": [
-    "I found the elm.json associated with jfmengels/node-elm-review repository on GitHub,\nbut I encountered a problem when parsing it:\n\nUnexpected token / in JSON at position 137"
+    "I found the elm.json associated with jfmengels/node-elm-review repository on GitHub,\nbut I encountered a problem when parsing it:\n\nUnexpected token / in JSON at position 135"
   ]
 }

--- a/test/run-snapshots/remote-configuration-with-unparsable-elmjson.txt
+++ b/test/run-snapshots/remote-configuration-with-unparsable-elmjson.txt
@@ -5,5 +5,5 @@
 I found the elm.json associated with jfmengels/node-elm-review repository on GitHub,
 but I encountered a problem when parsing it:
 
-Unexpected token / in JSON at position 137
+Unexpected token / in JSON at position 135
 


### PR DESCRIPTION
Fixes the build error introduced by https://github.com/jfmengels/node-elm-review/pull/295

The test is for running a remote configuration, so this was bound to fail, but I hadn't noticed it when I did the edit.