### PR TITLE
Resolve --compiler and --elm-format-path from PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Publicly document the `--fix-all-without-prompt` CLI flag. Please use it well!
 - The `--compiler` flag now additionally resolves the compiler path using the `PATH` environment variable (more easily enabling `elm-review --compiler lamdera` for instance).
+- The `--elm-format-path` flag now additionally resolves the path to `elm-format` using the `PATH` environment variable.
 - Fixed an issue where the initial rule created with `elm-review new-package` was always a module rule, even when it was requested to be a project rule. Thanks to [@mateusfpleite](https://github.com/mateusfpleite)!
 - Plenty of behind the scenes improvement to the maintenance of the repository. Thanks to [@lishaduck](https://github.com/lishaduck) for all of those.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Publicly document the `--fix-all-without-prompt` CLI flag. Please use it well!
+- The `--compiler` flag now additionally resolves the compiler path using the `PATH` environment variable (more easily enabling `elm-review --compiler lamdera` for instance).
 - Fixed an issue where the initial rule created with `elm-review new-package` was always a module rule, even when it was requested to be a project rule. Thanks to [@mateusfpleite](https://github.com/mateusfpleite)!
 - Plenty of behind the scenes improvement to the maintenance of the repository. Thanks to [@lishaduck](https://github.com/lishaduck) for all of those.
 

--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -188,9 +188,10 @@ function formatFileContent(options, file, filePath) {
     ['--elm-version=0.19', '--stdin', '--output', filePath],
     {
       input: file.source,
-      env: hasElmFormatPathFlag
-        ? process.env
-        : {...process.env, [pathKey]: backwardsCompatiblePath()}
+      env: {
+        ...process.env,
+        [pathKey]: backwardsCompatiblePath(options.elmFormatPath)
+      }
     }
   );
 

--- a/lib/elm-binary.js
+++ b/lib/elm-binary.js
@@ -17,32 +17,27 @@ const {backwardsCompatiblePath} = require('./npx');
  * @returns {Promise<Path>}
  */
 async function getElmBinary(options) {
-  if (options.compiler === undefined) {
-    try {
-      return await which('elm', {path: backwardsCompatiblePath()});
-    } catch {
-      throw new ErrorMessage.CustomError(
-        // prettier-ignore
-        'ELM NOT FOUND',
-        // prettier-ignore
-        `I could not find the executable for the ${chalk.magentaBright('elm')} compiler.
+  let pathFolders = backwardsCompatiblePath();
+  if (options.compiler) {
+    pathFolders = pathFolders + path.delimiter + options.userSrc();
+  }
+  try {
+    const elmBinaryPath = await which(options.compiler ?? 'elm', {
+      path: pathFolders
+    });
+    return path.resolve(elmBinaryPath);
+  } catch {
+    throw new ErrorMessage.CustomError(
+      'ELM NOT FOUND',
+      options.compiler === undefined
+        ? // prettier-ignore
+          `I could not find the executable for the ${chalk.magentaBright('elm')} compiler.
 
 A few options:
 - Install it globally
-- Specify the path using ${chalk.cyan('--compiler <path-to-elm>')}`,
-        options.elmJsonPath
-      );
-    }
-  }
-
-  try {
-    return await which(path.resolve(options.compiler));
-  } catch {
-    throw new ErrorMessage.CustomError(
-      // prettier-ignore
-      'ELM NOT FOUND',
-      // prettier-ignore
-      `I could not find the executable for the ${chalk.magentaBright('elm')} compiler at the location you specified:
+- Specify the path using ${chalk.cyan('--compiler <path-to-elm>')}`
+        : // prettier-ignore
+          `I could not find the executable for the ${chalk.magentaBright('elm')} compiler at the location you specified:
   ${options.compiler}`,
       options.elmJsonPath
     );

--- a/lib/elm-binary.js
+++ b/lib/elm-binary.js
@@ -17,13 +17,9 @@ const {backwardsCompatiblePath} = require('./npx');
  * @returns {Promise<Path>}
  */
 async function getElmBinary(options) {
-  let pathFolders = backwardsCompatiblePath();
-  if (options.compiler) {
-    pathFolders = pathFolders + path.delimiter + options.userSrc();
-  }
   try {
     const elmBinaryPath = await which(options.compiler ?? 'elm', {
-      path: pathFolders
+      path: backwardsCompatiblePath(options.compiler)
     });
     return path.resolve(elmBinaryPath);
   } catch {

--- a/lib/npx.js
+++ b/lib/npx.js
@@ -61,9 +61,10 @@ const pathKey = getPathKey();
  *
  * This can be removed in a major version.
  *
+ * @param {Path | undefined} providedBinaryPath
  * @returns {Path}
  */
-function backwardsCompatiblePath() {
+function backwardsCompatiblePath(providedBinaryPath) {
   return [
     ...process
       .cwd()
@@ -72,6 +73,11 @@ function backwardsCompatiblePath() {
         [...parts.slice(0, index + 1), 'node_modules', '.bin'].join(path.sep)
       )
       .reverse(),
+    [
+      ...(providedBinaryPath
+        ? [path.resolve(path.dirname(providedBinaryPath))]
+        : [])
+    ],
     process.env[pathKey]
   ].join(path.delimiter);
 }

--- a/test/compiler-flag.test.js
+++ b/test/compiler-flag.test.js
@@ -1,0 +1,35 @@
+const TestCli = require('./jest-helpers/cli');
+const snapshotter = require('./snapshotter');
+
+/**
+ * @template {string} N
+ * @param {N} name
+ * @returns {`test/snapshots/compiler-flag/${N}.txt`}
+ */
+function testName(name) {
+  return snapshotter.snapshotPath('compiler-flag', name);
+}
+
+test('should retrieve `elm` binary from PATH', async () => {
+  const output = await TestCli.run(
+    '--config ../config-that-triggers-no-errors --force-build --compiler elm',
+    {project: 'project-with-errors/'}
+  );
+  expect(output).toEqual('I found no errors!\n');
+});
+
+test('should retrieve `elm` binary locally when path is relative', async () => {
+  const output = await TestCli.run(
+    '--config ../config-that-triggers-no-errors --force-build --compiler ../../node_modules/.bin/elm',
+    {project: 'project-with-errors/'}
+  );
+  expect(output).toEqual('I found no errors!\n');
+});
+
+test('should report an error when compiler could not be found', async () => {
+  const output = await TestCli.runAndExpectError(
+    '--config ../config-that-triggers-no-errors --force-build --compiler notfound',
+    {project: 'project-using-es2015-module'}
+  );
+  expect(output).toMatchFile(testName('compiler-not-found'));
+});

--- a/test/snapshots/compiler-flag/compiler-not-found.txt
+++ b/test/snapshots/compiler-flag/compiler-not-found.txt
@@ -1,0 +1,5 @@
+-- ELM NOT FOUND ---------------------------------------------------------------
+
+I could not find the executable for the elm compiler at the location you specified:
+  notfound
+


### PR DESCRIPTION
- The `--compiler` flag now additionally resolves the compiler path using the `PATH` environment variable (more easily enabling `elm-review --compiler lamdera` for instance).
- The `--elm-format-path` flag now additionally resolves the path to `elm-format` using the `PATH` environment variable.

cc @Janiczek who reported the issue on Slack.