### PR TITLE
Replace GITHUB_AUTH by AUTH_GITHUB

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -14,14 +14,14 @@ replace_script() {
 }
 
 # If you get errors like rate limit exceeded, you can run these tests
-# with "GITHUB_AUTH=gitHubUserName:token"
+# with "AUTH_GITHUB=gitHubUserName:token"
 # Follow this guide: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
 # to create an API token, and give it access to public repositories.
-if [ -z "${GITHUB_AUTH:-}" ]
+if [ -z "${AUTH_GITHUB:-}" ]
 then
   AUTH=""
 else
-  AUTH=" --github-auth $GITHUB_AUTH"
+  AUTH=" --github-auth $AUTH_GITHUB"
 fi
 
 runCommandAndCompareToSnapshot() {

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["NO_COLOR", "LOCAL_ELM_REVIEW_SRC", "ELM_HOME"],
-  "globalPassThroughEnv": ["GITHUB_TOKEN", "GITHUB_AUTH"],
+  "globalPassThroughEnv": ["GITHUB_TOKEN", "AUTH_GITHUB"],
   "tasks": {
     "elm-format": {
       "inputs": [


### PR DESCRIPTION
Environment variables in GitHub can't start with "GITHUB_".

I created an environment for GitHub Actions with a `AUTH_GITHUB`, which will be used for tests that use `--template`. Hopefully this will help prevent rate limits :crossed_fingers: 