### PR TITLE
Use GHA's token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,3 +94,5 @@ jobs:
 
     - name: Run tests
       run: npm test
+      env:
+        AUTH_GITHUB: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,4 +95,4 @@ jobs:
     - name: Run tests
       run: npm test
       env:
-        AUTH_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        AUTH_GITHUB: ${{ github.token }}

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -23,7 +23,7 @@ const gitHubAuthFlag = {
     'Follow https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token. The API token needs access to public repositories.',
     '',
     'Then use the flag like this:',
-    chalk.greenBright('  --github-auth=my-user-name:abcdef01234567890')
+    chalk.greenBright('  --github-auth=github_pat_abcdef01234567890')
   ]
 };
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -181,12 +181,7 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
 
   const forTests = args['FOR-TESTS'];
 
-  // eslint-disable-next-line unicorn/no-useless-undefined -- Bad TS type.
-  const {gitHubUser = undefined, gitHubPassword = undefined} = args[
-    'github-auth'
-  ]
-    ? parseGitHubAuth(subcommand, args['github-auth'])
-    : {};
+  const gitHubPat = parseGitHubAuth(subcommand, args['github-auth']);
 
   const localElmReviewSrc = process.env.LOCAL_ELM_REVIEW_SRC;
 
@@ -326,9 +321,8 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
     resultCachePath: (appHash) =>
       path.join(elmStuffFolder(), 'result-cache', appHash),
 
-    // GitHub tokens
-    gitHubUser,
-    gitHubPassword
+    // GitHub token
+    gitHubPat
   };
 }
 
@@ -655,12 +649,14 @@ I recommend you try to gain network access and try again.`,
 
 /**
  * @param {Subcommand | null} subcommand
- * @param {string} gitHubAuth
- * @returns {{gitHubUser: string | undefined, gitHubPassword: string | undefined} | never}
+ * @param {string | undefined} gitHubAuth
+ * @returns {string | undefined | never}
  */
 function parseGitHubAuth(subcommand, gitHubAuth) {
+  if (gitHubAuth === undefined) return;
+
   const split = gitHubAuth.split(':');
-  if (split.length !== 2) {
+  if (split.length !== 2 && split.length !== 1) {
     reportErrorAndExit(
       new ErrorMessage.CustomError(
         'INVALID FLAG ARGUMENT',
@@ -675,8 +671,7 @@ ${Flags.buildFlag(subcommand, Flags.gitHubAuthFlag)}`
     );
   }
 
-  const [gitHubUser, gitHubPassword] = split;
-  return {gitHubUser, gitHubPassword};
+  return split.length === 2 ? split[1] : split[0];
 }
 
 /**

--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -197,21 +197,31 @@ ${error.message}`
   }
 }
 
-/** @type {ErrorMessageInfo} */
-const rateLimitErrorMessage = {
-  title: 'GITHUB RATE LIMIT EXCEEDED',
-  message: `It looks like you exceeded the GitHub rate limit by using "--template" too many
-times, this will likely last for 30 minutes.
-
+/**
+ * @param {boolean} hasPat
+ * @param {string} resetTime
+ * @returns {ErrorMessageInfo}
+ */
+function rateLimitErrorMessage(hasPat, resetTime) {
+  return {
+    title: 'GITHUB RATE LIMIT EXCEEDED',
+    message: `It looks like you exceeded the GitHub rate limit by using "--template" too many
+times, this will likely last until ${resetTime}.
+${
+  hasPat
+    ? ''
+    : `
 In the meantime, you can use \`--github-auth=your-api-token\`.
-Follow this guide: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token, and give it access to public repositories.
+Follow this guide: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token, and give it access to public repositories.`
+}
 
 To avoid this problem and to make the review process faster, consider setting up
 elm-review in your project:
 
     elm-review init
     elm-review init --template <some-configuration>`
-};
+  };
+}
 
 /**
  * @param {string} repoName
@@ -380,11 +390,14 @@ async function makeGitHubApiRequest(options, url, handleNotFound) {
     Debug.log(`# body:\n${JSON.stringify(error.response.body, null, 4)}`);
     if (error.name === 'HTTPError') {
       switch (error.response.statusCode) {
+        case 429:
         case 403: {
-          throw new ErrorMessage.CustomError(
-            rateLimitErrorMessage.title,
-            rateLimitErrorMessage.message
-          );
+          const hasPat = options.gitHubPat !== undefined;
+          const rateLimitReset = error.response.headers['x-ratelimit-reset'];
+          const resetTime = new Date(rateLimitReset * 1000).toLocaleString();
+          const {title, message} = rateLimitErrorMessage(hasPat, resetTime);
+
+          throw new ErrorMessage.CustomError(title, message);
         }
 
         case 404:

--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -371,7 +371,10 @@ async function makeGitHubApiRequest(options, url, handleNotFound) {
   /** @type {OptionsOfJSONResponseBody} */
   const parameters = {
     responseType: 'json',
-    headers: {Authorization: `BEARER: ${options.gitHubPat}`}
+    headers: {
+      Authorization: `BEARER: ${options.gitHubPat}`,
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
   };
 
   Debug.log(`Making API request to GitHub: ${url}`);

--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -203,7 +203,7 @@ const rateLimitErrorMessage = {
   message: `It looks like you exceeded the GitHub rate limit by using "--template" too many
 times, this will likely last for 30 minutes.
 
-In the meantime, you can use \`--github-auth your-github-username:your-api-token\`.
+In the meantime, you can use \`--github-auth=your-api-token\`.
 Follow this guide: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token, and give it access to public repositories.
 
 To avoid this problem and to make the review process faster, consider setting up
@@ -358,12 +358,11 @@ async function downloadFile(url, dest) {
  * @returns {Promise<unknown>}
  */
 async function makeGitHubApiRequest(options, url, handleNotFound) {
-  /** @type {OptionsOfJSONResponseBody}} */
-  const parameters = {responseType: 'json'};
-  if (options.gitHubUser && options.gitHubPassword) {
-    parameters.username = options.gitHubUser;
-    parameters.password = options.gitHubPassword;
-  }
+  /** @type {OptionsOfJSONResponseBody} */
+  const parameters = {
+    responseType: 'json',
+    headers: {Authorization: `BEARER: ${options.gitHubPat}`}
+  };
 
   Debug.log(`Making API request to GitHub: ${url}`);
   try {

--- a/lib/types/options.ts
+++ b/lib/types/options.ts
@@ -63,8 +63,7 @@ export type Options = OptionsBase & {
   fileCachePath: () => Path;
   resultCachePath: (appHash: AppHash) => Path;
 
-  gitHubUser: string | undefined;
-  gitHubPassword: string | undefined;
+  gitHubPat?: string | undefined;
 };
 
 export type ReviewOptions = Options & {

--- a/test/flags.test.js
+++ b/test/flags.test.js
@@ -96,7 +96,7 @@ test('Running new-package --compiler without an argument', async () => {
 });
 
 test('Running --github-auth with a bad value', async () => {
-  const output = await TestCli.runAndExpectError(['--github-auth=bad']);
+  const output = await TestCli.runAndExpectError(['--github-auth=::']);
   expect(output).toMatchFile(testName('github-auth-bad-argument'));
 });
 

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -1,4 +1,12 @@
 #!/bin/node
+
+/*
+ * If you get errors like "rate limit exceeded",
+ * you can run these tests with `AUTH_GITHUB=token`.
+ * Follow this guide: <https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token> to create an API token,
+ * and give it access to public repositories.
+ */
+
 /* eslint n/no-process-exit: "off" -- WIP */
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';

--- a/test/snapshots/flags/github-auth-bad-argument.txt
+++ b/test/snapshots/flags/github-auth-bad-argument.txt
@@ -1,6 +1,6 @@
 -- INVALID FLAG ARGUMENT -------------------------------------------------------
 
-The value bad passed to --github-auth is not a valid one.
+The value :: passed to --github-auth is not a valid one.
 
 Here is the documentation for this flag:
 

--- a/test/snapshots/flags/github-auth-bad-argument.txt
+++ b/test/snapshots/flags/github-auth-bad-argument.txt
@@ -9,5 +9,5 @@ Here is the documentation for this flag:
         Follow https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token. The API token needs access to public repositories.
 
         Then use the flag like this:
-          --github-auth=my-user-name:abcdef01234567890
+          --github-auth=github_pat_abcdef01234567890
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["NO_COLOR", "LOCAL_ELM_REVIEW_SRC", "ELM_HOME"],
-  "globalPassThroughEnv": ["AUTH_GITHUB"],
+  "globalEnv": ["NO_COLOR", "LOCAL_ELM_REVIEW_SRC"],
+  "globalPassThroughEnv": ["AUTH_GITHUB", "ELM_HOME"],
   "tasks": {
     "elm-format": {
       "inputs": [

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["NO_COLOR", "LOCAL_ELM_REVIEW_SRC", "ELM_HOME"],
-  "globalPassThroughEnv": ["GITHUB_TOKEN", "AUTH_GITHUB"],
+  "globalPassThroughEnv": ["AUTH_GITHUB"],
   "tasks": {
     "elm-format": {
       "inputs": [


### PR DESCRIPTION
GHA provides a token itself, we don't need to generate one. This is more-fine grained, easier to change if needed, and more secure.

I think the existing `contents: read` is sufficient, but it might not be. We'll see.

Based on https://github.com/jfmengels/node-elm-review/pull/309#issuecomment-2467063929.

Closes #336.