### PR TITLE
Set `esModuleInterop` to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prettier-check": "prettier . --check --cache",
     "prettier-fix": "prettier . --write --cache",
     "test": "turbo run testing check-engines --continue",
+    "test-sync": "npm run test-run && npm run jest",
     "test-run": "(cd test/ && ./run.sh)",
     "test-run-record": "(cd test/ && ./run.sh record)",
     "tsc": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleResolution": "Node16",
     "target": "es2020",
     "lib": ["ES2020"],
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": false,
     "noEmit": true,
     "noImplicitThis": true,

--- a/turbo.json
+++ b/turbo.json
@@ -26,8 +26,7 @@
         "tsc",
         "eslint-check",
         "prettier-check",
-        "jest",
-        "test-run"
+        "test-sync"
       ]
     },
     "testing:offline": {
@@ -38,6 +37,20 @@
         "eslint-check",
         "prettier-check",
         "jest"
+      ]
+    },
+    "test-sync": {
+      "inputs": [
+        "ast-codec/",
+        "bin/",
+        "init-templates/",
+        "lib/",
+        "new-package/",
+        "parseElm/",
+        "review/",
+        "template/",
+        "test/",
+        "vendor/"
       ]
     },
     "eslint-check": {


### PR DESCRIPTION
I turned it off a while ago, but it should be on. It's `allowSyntheticDefaultImports` that should be off.