### PR TITLE
Don't stall if elm-review app has no files to analyze

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -72,6 +72,11 @@ async function sendProjectContent(
   app.ports.collectExtraFiles.send(extraFiles);
 
   await new Promise((/** @type {(value?: never) => void} */ resolve) => {
+    if (filesPendingReceiptAcknowledgement.size === 0) {
+      resolve();
+      return;
+    }
+
     app.ports.acknowledgeFileReceipt.subscribe(acknowledgeFileReceipt);
     for (const file of elmFiles) {
       app.ports.collectFile.send(file);


### PR DESCRIPTION
For #340

This will stop the app from hanging, but I don't think we should ever be in this scenario in the first place if everything else is working as expected.