### PR TITLE
Reduce blank lines in rate limit warning

### DIFF
--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -203,17 +203,16 @@ ${error.message}`
  * @returns {ErrorMessageInfo}
  */
 function rateLimitErrorMessage(hasPat, resetTime) {
+  const patAdvice = hasPat
+    ? ''
+    : `In the meantime, you can use \`--github-auth=your-api-token\`.
+Follow this guide: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token, and give it access to public repositories.`;
+
   return {
     title: 'GITHUB RATE LIMIT EXCEEDED',
     message: `It looks like you exceeded the GitHub rate limit by using "--template" too many
 times, this will likely last until ${resetTime}.
-${
-  hasPat
-    ? ''
-    : `In the meantime, you can use \`--github-auth=your-api-token\`.
-Follow this guide: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token, and give it access to public repositories.`
-}
-
+${patAdvice}
 To avoid this problem and to make the review process faster, consider setting up
 elm-review in your project:
 

--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -210,8 +210,7 @@ times, this will likely last until ${resetTime}.
 ${
   hasPat
     ? ''
-    : `
-In the meantime, you can use \`--github-auth=your-api-token\`.
+    : `In the meantime, you can use \`--github-auth=your-api-token\`.
 Follow this guide: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token to create an API token, and give it access to public repositories.`
 }
 


### PR DESCRIPTION
```
-- GITHUB RATE LIMIT EXCEEDED --------------------------------------------------

It looks like you exceeded the GitHub rate limit by using "--template" too many
times, this will likely last until 2/22/2025, 5:38:30 PM.
<--- There were 2 empty lines here, there is now only one --->

To avoid this problem and to make the review process faster, consider setting up
elm-review in your project:

    elm-review init
    elm-review init --template <some-configuration>
```