### PR TITLE
Report errors if no files were found or if source-directories are empty

### DIFF
--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -13,6 +13,7 @@ const Debug = require('./debug');
 const ErrorMessage = require('./error-message');
 const FS = require('./fs-wrapper');
 const Hash = require('./hash');
+const {unique} = require('./utils');
 const OsHelpers = require('./os-helpers');
 const elmParser = require('./parse-elm');
 const AppState = require('./state');
@@ -232,8 +233,10 @@ function getSourceDirectories(options, elmJson) {
   if (options.directoriesToAnalyze.length > 0) {
     return {
       isFromCliArguments: true,
-      sourceDirectories: options.directoriesToAnalyze.map((directory) =>
-        path.resolve(process.cwd(), directory)
+      sourceDirectories: unique(
+        options.directoriesToAnalyze.map((directory) =>
+          path.resolve(process.cwd(), directory)
+        )
       )
     };
   }
@@ -263,7 +266,7 @@ function standardSourceDirectories(options, elmJson) {
 
   // If the project is an "application"
 
-  return [
+  return unique([
     ...elmJson['source-directories'].flatMap(
       (/** @type {Path} */ directory) => [
         path.join(projectToReview, directory),
@@ -271,7 +274,7 @@ function standardSourceDirectories(options, elmJson) {
       ]
     ),
     path.join(projectToReview, 'tests')
-  ];
+  ]);
 }
 
 /**

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -53,6 +53,9 @@ async function getProjectFiles(options, elmSyntaxVersion) {
   const emptyDirectories = filesInDirectories.filter(
     ({files}) => files.length === 0
   );
+  const elmFilesToRead = [
+    ...new Set(filesInDirectories.flatMap((directory) => directory.files))
+  ];
 
   // TODO(@jfmengels): Have a different message depending on how directories were chosen (CLI directories, application, package).
   if (options.directoriesToAnalyze.length > 0 && emptyDirectories.length > 0) {
@@ -65,6 +68,12 @@ ${emptyDirectories.map(({directory}) => `- ${directory}`).join('\n')}
 When I can’t find files in some of the directories, I’m assuming that you
 misconfigured the CLI’s arguments.`
     );
+  } else if (elmFilesToRead.length === 0) {
+    throw new ErrorMessage.CustomError(
+      'NO FILES FOUND',
+      `I could not find any files in this project. I looked in these folders:
+${sourceDirectories.map((directory) => `- ${directory}`).join('\n')}`
+    );
   }
 
   Debug.log(`Parsing using stil4m/elm-syntax v${elmSyntaxVersion}`);
@@ -73,9 +82,6 @@ misconfigured the CLI’s arguments.`
   Benchmark.start(options, 'parse/fetch parsed files');
   const elmParserPath = options.elmParserPath(elmSyntaxVersion);
   elmParser.prepareWorkers();
-  const elmFilesToRead = [
-    ...new Set(filesInDirectories.flatMap((directory) => directory.files))
-  ];
   const elmFiles = await Promise.all(
     elmFilesToRead.map(
       async (filePath) =>

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -271,14 +271,21 @@ function standardSourceDirectories(options, elmJson) {
   }
 
   // If the project is an "application"
+  const sourceDirectories = elmJson['source-directories'] ?? [];
+  if (sourceDirectories.length === 0) {
+    throw new ErrorMessage.CustomError(
+      'EMPTY SOURCE-DIRECTORIES',
+      `The \`source-directories\` in your \`elm.json\` is empty. I need it to contain
+at least 1 directory in order to find files to analyze. The Elm compiler will
+need that as well anyway.`
+    );
+  }
 
   return unique([
-    ...elmJson['source-directories'].flatMap(
-      (/** @type {Path} */ directory) => [
-        path.join(projectToReview, directory),
-        path.resolve(projectToReview, directory, '../tests/')
-      ]
-    ),
+    ...sourceDirectories.flatMap((/** @type {Path} */ directory) => [
+      path.join(projectToReview, directory),
+      path.resolve(projectToReview, directory, '../tests/')
+    ]),
     path.join(projectToReview, 'tests')
   ]);
 }

--- a/test/project-empty-source-directories/elm.json
+++ b/test/project-empty-source-directories/elm.json
@@ -1,0 +1,19 @@
+{
+    "type": "application",
+    "source-directories": [],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/virtual-dom": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/test/project-empty-source-directories/src/Main.elm
+++ b/test/project-empty-source-directories/src/Main.elm
@@ -1,0 +1,13 @@
+module Main exposing (main)
+
+import Html exposing (Html)
+
+
+main : Html msg
+main =
+    Html.text "main"
+
+
+unused : Int
+unused =
+    1

--- a/test/project-empty/elm.json
+++ b/test/project-empty/elm.json
@@ -1,0 +1,24 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/test/review.test.js
+++ b/test/review.test.js
@@ -123,6 +123,14 @@ test('Running on project with unknown file', async () => {
   expect(output).toMatchFile(testName('run-with-unknown-target'));
 });
 
+test('Running on project with no files', async () => {
+  const output = await TestCli.runAndExpectError(
+    ['--config=../project-with-errors/review'],
+    {project: 'project-empty'}
+  );
+  expect(output).toMatchFile(testName('run-with-empty-project'));
+});
+
 test('Running on project with a directory ending in .elm (without arg)', async () => {
   const output = await TestCli.run(
     ['--config', '../config-that-triggers-no-errors'],

--- a/test/review.test.js
+++ b/test/review.test.js
@@ -131,6 +131,14 @@ test('Running on project with no files', async () => {
   expect(output).toMatchFile(testName('run-with-empty-project'));
 });
 
+test('Running on project with no files', async () => {
+  const output = await TestCli.runAndExpectError(
+    ['--config=../project-with-errors/review'],
+    {project: 'project-empty-source-directories'}
+  );
+  expect(output).toMatchFile(testName('run-with-empty-source-directories'));
+});
+
 test('Running on project with a directory ending in .elm (without arg)', async () => {
   const output = await TestCli.run(
     ['--config', '../config-that-triggers-no-errors'],

--- a/test/snapshots/review/run-with-empty-project.txt
+++ b/test/snapshots/review/run-with-empty-project.txt
@@ -1,0 +1,6 @@
+-- NO FILES FOUND --------------------------------------------------------------
+
+I could not find any files in this project. I looked in these folders:
+- <local-path>/test/project-empty/src
+- <local-path>/test/project-empty/tests
+

--- a/test/snapshots/review/run-with-empty-source-directories.txt
+++ b/test/snapshots/review/run-with-empty-source-directories.txt
@@ -1,0 +1,6 @@
+-- EMPTY SOURCE-DIRECTORIES ----------------------------------------------------
+
+The `source-directories` in your `elm.json` is empty. I need it to contain
+at least 1 directory in order to find files to analyze. The Elm compiler will
+need that as well anyway.
+


### PR DESCRIPTION
Supersedes #341, by addressing the root problem.

As @lishaduck pointed out in https://github.com/jfmengels/node-elm-review/pull/341#issuecomment-2676439308

> we don't have any tests where there isn't a source dir, do we? I have a sneaking suspicion that the reason it hung was that tinyglobby <0.2.11 would've scanned the entire drive when given an absolute path, but in case I'm wrong there, we should probably make sure elm-review doesn't hang in the actual situation where there aren't any files.

Indeed, when there are no Elm files at all, `elm-review` hangs. I added a test for it, and we're now exiting with an error should that happen. I also added a specific error (and test) for when `source-directories` is empty for some reason.

I also `unique`d source-directories we're running, because there was some duplicates otherwise, and that was one additional `glob` call.