### PR TITLE
Fix --template used without --github-auth

### DIFF
--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -401,6 +401,15 @@ async function makeGitHubApiRequest(options, url, handleNotFound) {
           throw new ErrorMessage.CustomError(title, message);
         }
 
+        case 401: {
+          throw new ErrorMessage.CustomError(
+            'INVALID GITHUB CREDENTIALS',
+            `It looks like the credentials that were provided using \`--github-auth\` were incorrect.
+
+Please check that the credentials were correctly entered and that they are still valid.`
+          );
+        }
+
         case 404:
         case 422: {
           if (handleNotFound) {

--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -370,7 +370,7 @@ async function makeGitHubApiRequest(options, url, handleNotFound) {
   const parameters = {
     responseType: 'json',
     headers: {
-      Authorization: `BEARER ${options.gitHubPat}`,
+      Authorization: options.gitHubPat && `BEARER ${options.gitHubPat}`,
       'X-GitHub-Api-Version': '2022-11-28'
     }
   };


### PR DESCRIPTION
If `options.gitHubPat` was undefined, then we sent out `Authorization: BEARER undefined`, which yields a 401 HTTP error. So `--template` was **only** working with `--github-auth`.

I also made a nice error message when we get 401 responses, that should make it more obvious (mostly for us :smile:).