### PR TITLE
optimize-js: Make it so that interconnected optimizations are either all applied or all ignored

### DIFF
--- a/lib/optimize-js.js
+++ b/lib/optimize-js.js
@@ -22,28 +22,53 @@ async function optimize(options, elmModulePath, isReviewApp) {
     : 'optimizing parser application';
   Benchmark.start(options, timerId);
   const originalSource = await FS.readFile(elmModulePath);
+  const packageName = options.localElmReviewSrc
+    ? '$author$project'
+    : '$jfmengels$elm_review';
   const replacements = isReviewApp
     ? [
-        ...performanceReplacements,
-        ...cacheReplacements(options.localElmReviewSrc)
+        ...coreElmPerformanceReplacements.map((replacement) => [replacement]),
+        fasterCreateRuleModuleVisitor(packageName),
+        mutatingMapReplacement(packageName),
+        ...cacheReplacements(packageName).map((replacement) => [replacement])
       ]
-    : performanceReplacements;
+    : coreElmPerformanceReplacements.map((replacement) => [replacement]);
 
-  const newSource = replacements
-    .reduce((source, {target, replacement}) => {
-      return source.replace(target, replacement);
-    }, originalSource)
-    .replace(
-      /var ([\w$]+) = F(\d)\(\s*function\s*\(/g,
-      'var $1 = F$2(function $1$fn('
-    );
+  const newSource = applyReplacements(originalSource, replacements);
 
   await FS.writeFile(elmModulePath, newSource);
   Benchmark.end(options, timerId);
   return elmModulePath;
 }
 
-const performanceReplacements = [
+/**
+ * @param {string} originalSource
+ * @param {Optimization[][]} replacementGroups
+ * @returns {string}
+ */
+function applyReplacements(originalSource, replacementGroups) {
+  return replacementGroups.reduce(applyReplacementForGroups, originalSource);
+}
+
+/** Apply all replacements of a group. If any of the replacements can't be applied, then apply none of them.
+ * @param {string} originalSource
+ * @param {Optimization[]} replacementGroup
+ * @returns {string}
+ */
+function applyReplacementForGroups(originalSource, replacementGroup) {
+  let source = originalSource;
+  for (const {target, replacement} of replacementGroup) {
+    if (!source.includes(target)) {
+      return originalSource;
+    }
+
+    source = source.replace(target, replacement);
+  }
+
+  return source;
+}
+
+const coreElmPerformanceReplacements = [
   {
     target: `var $elm$core$List$all = F2(
 \tfunction (isOkay, list) {
@@ -423,13 +448,72 @@ const performanceReplacements = [
 ];
 
 /**
- * @param {string | undefined} localElmReviewSrc
+ * @param {string} packageName
  * @returns {Optimization[]}
  */
-function cacheReplacements(localElmReviewSrc) {
-  const packageName = localElmReviewSrc
-    ? '$author$project'
-    : '$jfmengels$elm_review';
+function fasterCreateRuleModuleVisitor(packageName) {
+  return [
+    {
+      target: `var ${packageName}$Review$Rule$createRuleModuleVisitor = F4(
+\tfunction (schema, params, toRuleProjectVisitor, initialContext) {
+\t\tvar raise = function (errorsAndContext) {
+\t\t\treturn {`,
+      replacement: `var ${packageName}$Review$Rule$createRuleModuleVisitor = F4(
+  function (schema, params, toRuleProjectVisitor, initialContext) {
+    var raise = function (errorsAndContext) {
+      function raise(_v0) {
+        errorsAndContext.a = _v0.a;
+        errorsAndContext.b = _v0.b;
+      }
+      return {`
+    }
+  ];
+}
+
+/**
+ * @param {string} packageName
+ * @returns {Optimization[]}
+ */
+function mutatingMapReplacement(packageName) {
+  return [
+    {
+      target: `var ${packageName}$Review$Rule$fromJsArrayToList = function (_v0) {
+\tvar list = _v0;
+\treturn list;
+};`,
+      replacement: `var ${packageName}$Review$Rule$fromJsArrayToList = _List_fromArray;`
+    },
+    {
+      target: `var ${packageName}$Review$Rule$fromListToJsArray = $elm$core$Basics$identity;`,
+      replacement: `var ${packageName}$Review$Rule$fromListToJsArray = _List_toArray;`
+    },
+    {
+      target: `var ${packageName}$Review$Rule$mutatingMap = F2(
+\tfunction (mapper, _v0) {
+\t\tvar list = _v0;
+\t\treturn A2($elm$core$List$map, mapper, list);
+\t});`,
+      replacement: `var ${packageName}$Review$Rule$mutatingMap = F2(
+  function (mapper, arr) {
+    var len = arr.length;
+    for (var i = 0; i < len; i++) {
+      mapper(arr[i]);
+    }
+    return arr;
+  });`
+    },
+    {
+      target: `var ${packageName}$Review$Cache$ContextHash$sort = $elm$core$Basics$identity;`,
+      replacement: `var ${packageName}$Review$Cache$ContextHash$sort = function(l) { return $elm$core$List$sort(l); }`
+    }
+  ];
+}
+
+/**
+ * @param {string} packageName
+ * @returns {Optimization[]}
+ */
+function cacheReplacements(packageName) {
   return [
     {
       target: `var ${packageName}$Review$Rule$initialCacheMarker = F3(
@@ -484,50 +568,6 @@ function jsonToHash(json) {
   contextHashMap.set(json, hash);
   return hash;
 }`
-    },
-    {
-      target: `var ${packageName}$Review$Rule$createRuleModuleVisitor = F4(
-\tfunction (schema, params, toRuleProjectVisitor, initialContext) {
-\t\tvar raise = function (errorsAndContext) {
-\t\t\treturn {`,
-      replacement: `var ${packageName}$Review$Rule$createRuleModuleVisitor = F4(
-  function (schema, params, toRuleProjectVisitor, initialContext) {
-    var raise = function (errorsAndContext) {
-      function raise(_v0) {
-        errorsAndContext.a = _v0.a;
-        errorsAndContext.b = _v0.b;
-      }
-      return {`
-    },
-    {
-      target: `var ${packageName}$Review$Rule$fromJsArrayToList = function (_v0) {
-\tvar list = _v0;
-\treturn list;
-};`,
-      replacement: `var ${packageName}$Review$Rule$fromJsArrayToList = _List_fromArray;`
-    },
-    {
-      target: `var ${packageName}$Review$Rule$fromListToJsArray = $elm$core$Basics$identity;`,
-      replacement: `var ${packageName}$Review$Rule$fromListToJsArray = _List_toArray;`
-    },
-    {
-      target: `var ${packageName}$Review$Rule$mutatingMap = F2(
-\tfunction (mapper, _v0) {
-\t\tvar list = _v0;
-\t\treturn A2($elm$core$List$map, mapper, list);
-\t});`,
-      replacement: `var ${packageName}$Review$Rule$mutatingMap = F2(
-  function (mapper, arr) {
-    var len = arr.length;
-    for (var i = 0; i < len; i++) {
-      mapper(arr[i]);
-    }
-    return arr;
-  });`
-    },
-    {
-      target: `var ${packageName}$Review$Cache$ContextHash$sort = $elm$core$Basics$identity;`,
-      replacement: `var ${packageName}$Review$Cache$ContextHash$sort = function(l) { return $elm$core$List$sort(l); }`
     }
   ];
 }


### PR DESCRIPTION
This fixes an issue where with alternate compilers like Lamdera, only some definitions of the mutatingJS functions got replaced but not others, changing the behavior of the code. Now these are grouped together and they only get applied if all of them get applied.