### PR TITLE
Be more defensive about elm-format not being defined

### DIFF
--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -208,17 +208,9 @@ function formatFileContent(options, file, filePath) {
           'ELM-FORMAT NOT FOUND',
 
           // prettier-ignore
-          hasElmFormatPathFlag
-            ? `I could not find the executable for ${chalk.magentaBright('elm-format')} at the location you specified:
+          `I could not find the executable for ${chalk.magentaBright('elm-format')} at the location you specified:
 
   ${options.elmFormatPath}`
-            : `I could not find the executable for ${chalk.magentaBright('elm-format')}.
-
-A few options:
-- Install it globally.
-- Add it to your project through \`npm\`.
-- Specify the path using ${chalk.cyan('--elm-format-path <path-to-elm-format>')}.`,
-          options.elmJsonPath
         );
       }
     } else {

--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -227,12 +227,17 @@ A few options:
   }
 
   if (result.status !== 0) {
+    const errorMessage =
+      result?.stderr?.toString() ||
+      // prettier-ignore
+      `Unknown error. It's however very likely that ${chalk.magentaBright('elm-format')} is not installed for your project.`;
+
     throw new ErrorMessage.CustomError(
       'ERROR WHEN RUNNING ELM-FORMAT',
       // prettier-ignore
       `I got an unexpected error when running ${chalk.magentaBright('elm-format')}:
 
-${result.stderr.toString()}`,
+${errorMessage}`,
       options.elmJsonPath
     );
   }

--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -227,10 +227,9 @@ A few options:
   }
 
   if (result.status !== 0) {
-    const errorMessage =
-      result?.stderr?.toString() ||
-      // prettier-ignore
-      `Unknown error. It's however very likely that ${chalk.magentaBright('elm-format')} is not installed for your project.`;
+    const errorMessage = result.stderr
+      ? result.stderr.toString()
+      : JSON.stringify(result, null, 2);
 
     throw new ErrorMessage.CustomError(
       'ERROR WHEN RUNNING ELM-FORMAT',


### PR DESCRIPTION
It seems like it's possible for the `stderr` when failing to execute `elm-format` to be nullish.
(Found on a NixOS environment)

```
✔ Do you wish to apply this fix? … yes
-- UNEXPECTED ERROR ------------------------------------------------------------

I ran into an unexpected error. Please open an issue at the following link:
  https://github.com/jfmengels/node-elm-review/issues/new

Please include this error message and as much detail as you can provide. Running
with --debug might give additional information. If you can, please provide a
setup that makes it easy to reproduce the error. That will make it much easier
to fix the issue.

Below is the error that was encountered.
--------------------------------------------------------------------------------
TypeError: Cannot read properties of undefined (reading 'toString')
    at formatFileContent (/nix/store/wqdjz334kqr07l04c281q8n2jwra5ilq-elm-review-2.13.2/lib/node_modules/elm-review/lib/autofix.js:235:17)
    at /nix/store/wqdjz334kqr07l04c281q8n2jwra5ilq-elm-review-2.13.2/lib/node_modules/elm-review/lib/autofix.js:107:20
    at Array.map (<anonymous>)
    at Array.<anonymous> (/nix/store/wqdjz334kqr07l04c281q8n2jwra5ilq-elm-review-2.13.2/lib/node_modules/elm-review/lib/autofix.js:103:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

This fixes the issue by being more defensive about `result.stderr`.