### PR TITLE
Fix elm-review --template not working when pathToFolder is absent

### DIFF
--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -305,7 +305,7 @@ async function downloadDirectory(
     /** @type {({ type: string; name: string; download_url: string; })[]} */ (
       await makeGitHubApiRequest(
         options,
-        `https://api.github.com/repos/${repoName}/contents${pathToFolder}/${directory}?ref=${commit}`
+        `https://api.github.com/repos/${repoName}/contents/${pathToFolder}/${directory}?ref=${commit}`
           .split('//')
           .join('/')
       )


### PR DESCRIPTION
Before, the URL to download the contents of a repository could end up like
```
https:/api.github.com/repos/author/package/contentssrc?ref=abcdef...
```
instead of
```
https:/api.github.com/repos/author/package/contents/src?ref=abcdef...
```
The difference is the missing **`/`** after `contents`.
I don't know how or when this started breaking, it hasn't changed recently.