### PR TITLE
Remove check of `hasElmFormatPathFlag` in `ENOENT` error.

### DIFF
--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -15,10 +15,10 @@ const prompts = require('prompts');
 const exit = require('../vendor/exit');
 const ErrorMessage = require('./error-message');
 const FS = require('./fs-wrapper');
-const {backwardsCompatiblePath, pathKey} = require('./npx');
+const { backwardsCompatiblePath, pathKey } = require('./npx');
 const ProjectDependencies = require('./project-dependencies');
 const promisifyPort = require('./promisify-port');
-const {startReview} = require('./run-review');
+const { startReview } = require('./run-review');
 const AppState = require('./state');
 const StyledMessage = require('./styled-message');
 
@@ -203,24 +203,22 @@ function formatFileContent(options, file, filePath) {
 
   if (result.error) {
     if ('code' in result.error && result.error.code === 'ENOENT') {
-      if (hasElmFormatPathFlag) {
-        throw new ErrorMessage.CustomError(
-          'ELM-FORMAT NOT FOUND',
+      throw new ErrorMessage.CustomError(
+        'ELM-FORMAT NOT FOUND',
 
-          // prettier-ignore
-          hasElmFormatPathFlag
-            ? `I could not find the executable for ${chalk.magentaBright('elm-format')} at the location you specified:
+        // prettier-ignore
+        hasElmFormatPathFlag
+          ? `I could not find the executable for ${chalk.magentaBright('elm-format')} at the location you specified:
 
   ${options.elmFormatPath}`
-            : `I could not find the executable for ${chalk.magentaBright('elm-format')}.
+          : `I could not find the executable for ${chalk.magentaBright('elm-format')}.
 
 A few options:
 - Install it globally.
 - Add it to your project through \`npm\`.
 - Specify the path using ${chalk.cyan('--elm-format-path <path-to-elm-format>')}.`,
-          options.elmJsonPath
-        );
-      }
+        options.elmJsonPath
+      );
     } else {
       throw result.error;
     }

--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -15,10 +15,10 @@ const prompts = require('prompts');
 const exit = require('../vendor/exit');
 const ErrorMessage = require('./error-message');
 const FS = require('./fs-wrapper');
-const { backwardsCompatiblePath, pathKey } = require('./npx');
+const {backwardsCompatiblePath, pathKey} = require('./npx');
 const ProjectDependencies = require('./project-dependencies');
 const promisifyPort = require('./promisify-port');
-const { startReview } = require('./run-review');
+const {startReview} = require('./run-review');
 const AppState = require('./state');
 const StyledMessage = require('./styled-message');
 


### PR DESCRIPTION
This suggested change allows the correct error to be printed based on if the person running elm-review has specified the path to the elm-review executable or has not.