### PR TITLE
refactor: drop abstractions that make options evaluate strictly

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -156,18 +156,19 @@ I can help set you up with an initial configuration if you run ${chalk.magenta('
       `Review application is already built. Using ${Anonymize.path(
         options,
         elmModulePath
-      )}`
+      )}`,
+      options.debug
     );
   } else {
     const buildFolder = path.join(options.buildFolder(), 'review-project');
-    Debug.log('Starting review application build');
+    Debug.log('Starting review application build', options.debug);
 
     const [elmBinary] = await Promise.all([
       getElmBinary(options),
       createTemplateProject(options, userSrc, buildFolder, reviewElmJson)
     ]);
 
-    Debug.log('Compiling review application');
+    Debug.log('Compiling review application', options.debug);
     Benchmark.start(options, 'Compile review project');
 
     const buildResult = await compileElmProject(
@@ -182,7 +183,7 @@ I can help set you up with an initial configuration if you run ${chalk.magenta('
     Benchmark.end(options, 'Compile review project');
 
     if (buildResult) {
-      Debug.log('Finished review application build');
+      Debug.log('Finished review application build', options.debug);
     } else {
       elmModulePath = null;
     }
@@ -204,7 +205,11 @@ I can help set you up with an initial configuration if you run ${chalk.magenta('
  * @returns {Promise<BuildResult>}
  */
 async function buildFromGitHubTemplate(options, template) {
-  Spinner.setText('Fetching template information');
+  Spinner.setText(
+    'Fetching template information',
+    options.report,
+    options.forTests
+  );
   const commit = await RemoteTemplate.getRelevantCommit(options, template);
   const reviewElmJson = await RemoteTemplate.getRemoteElmJson(
     options,
@@ -213,7 +218,7 @@ async function buildFromGitHubTemplate(options, template) {
     commit,
     false
   );
-  Debug.log(`Commit is: ${commit}`);
+  Debug.log(`Commit is: ${commit}`, options.debug);
 
   /** @type {Path | null} */
   let elmModulePath = options.templateElmModulePath(commit);
@@ -222,10 +227,11 @@ async function buildFromGitHubTemplate(options, template) {
       `Review application is already built. Using ${Anonymize.path(
         options,
         elmModulePath
-      )}`
+      )}`,
+      options.debug
     );
 
-    Spinner.succeed();
+    Spinner.succeed(undefined, options.report);
   } else {
     const reviewElmJsonPath = options.pathToTemplateElmJson(commit);
 
@@ -233,7 +239,11 @@ async function buildFromGitHubTemplate(options, template) {
 
     const buildFolder = path.join(options.buildFolder(), 'template');
 
-    Spinner.setText('Downloading configuration files');
+    Spinner.setText(
+      'Downloading configuration files',
+      options.report,
+      options.forTests
+    );
     // Download all files from the template
     await RemoteTemplate.downloadSourceDirectories(
       options,
@@ -243,9 +253,13 @@ async function buildFromGitHubTemplate(options, template) {
       reviewElmJson
     );
 
-    Debug.log('Starting template review application build');
+    Debug.log('Starting template review application build', options.debug);
 
-    Spinner.setText('Building review application');
+    Spinner.setText(
+      'Building review application',
+      options.report,
+      options.forTests
+    );
 
     const reviewElmJsonWithReplacedParentDirectories = {
       ...reviewElmJson,
@@ -263,7 +277,7 @@ async function buildFromGitHubTemplate(options, template) {
       )
     ]);
 
-    Debug.log('Compiling template review application');
+    Debug.log('Compiling template review application', options.debug);
     const buildResult = await compileElmProject(
       options,
       path.join(buildFolder, 'project'),
@@ -274,12 +288,15 @@ async function buildFromGitHubTemplate(options, template) {
     );
 
     if (buildResult) {
-      Debug.log('Finished template review application build');
+      Debug.log('Finished template review application build', options.debug);
     } else {
       elmModulePath = null;
     }
 
-    Spinner.succeed('Build finished! Now reviewing your project...');
+    Spinner.succeed(
+      'Build finished! Now reviewing your project...',
+      options.report
+    );
   }
 
   return {
@@ -565,11 +582,17 @@ async function buildElmParser(options, reviewElmJson) {
     reviewElmJson.dependencies.indirect['stil4m/elm-syntax'];
   const elmParserPath = options.elmParserPath(elmSyntaxVersion);
   if (fs.existsSync(elmParserPath)) {
-    Debug.log(`Parser app for elm-syntax v${elmSyntaxVersion} already exists.`);
+    Debug.log(
+      `Parser app for elm-syntax v${elmSyntaxVersion} already exists.`,
+      options.debug
+    );
     return;
   }
 
-  Debug.log(`Building parser app for elm-syntax v${elmSyntaxVersion}`);
+  Debug.log(
+    `Building parser app for elm-syntax v${elmSyntaxVersion}`,
+    options.debug
+  );
 
   const buildFolder = options.buildFolderForParserApp();
 

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,13 +1,10 @@
-const AppState = require('./state');
-
-const options = AppState.getOptions();
-
 /**
  * @param {string} message
+ * @param {boolean} isDebug
  * @returns {void}
  */
-function log(message) {
-  if (options.debug) {
+function log(message, isDebug) {
+  if (isDebug) {
     console.log(message);
   }
 }

--- a/lib/elm-communication.js
+++ b/lib/elm-communication.js
@@ -28,7 +28,8 @@ function create(options) {
             const {ruleName, filePath, count} = message;
             if (options.debug) {
               Debug.log(
-                `Applying a fix for ${ruleName} in ${filePath} (${count} so far)`
+                `Applying a fix for ${ruleName} in ${filePath} (${count} so far)`,
+                options.debug
               );
             } else {
               if (!process.stdout.isTTY) {

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -76,8 +76,11 @@ ${sourceDirectories.map((directory) => `- ${directory}`).join('\n')}`
     );
   }
 
-  Debug.log(`Parsing using stil4m/elm-syntax v${elmSyntaxVersion}`);
-  Debug.log('Reviewing the following files:');
+  Debug.log(
+    `Parsing using stil4m/elm-syntax v${elmSyntaxVersion}`,
+    options.debug
+  );
+  Debug.log('Reviewing the following files:', options.debug);
 
   Benchmark.start(options, 'parse/fetch parsed files');
   const elmParserPath = options.elmParserPath(elmSyntaxVersion);
@@ -155,7 +158,7 @@ async function readFile(
   relativePathToElmJson,
   filePath
 ) {
-  Debug.log(` - ${Anonymize.path(options, filePath)}`);
+  Debug.log(` - ${Anonymize.path(options, filePath)}`, options.debug);
   const relativeFilePath = path.relative(relativePathToElmJson, filePath);
 
   const lastUpdatedTime = options.watch

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,7 +49,7 @@ process.on('unhandledRejection', errorHandler);
  * @returns {never}
  */
 function errorHandler(err) {
-  Spinner.fail();
+  Spinner.fail(undefined, options.report);
   let userSrc = null;
   try {
     userSrc = options.userSrc();

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,6 +25,7 @@ const Help = require('./help');
 const Init = require('./init');
 const NewPackage = require('./new-package');
 const NewRule = require('./new-rule');
+const Options_ = require('./options');
 const ResultCache = require('./result-cache');
 const Runner = require('./runner');
 const Spinner = require('./spinner');
@@ -35,8 +36,7 @@ const Watch = require('./watch');
 /**
  * @type {Options}
  */
-// TODO(@lishaduck): Centralize all calls to just this & move into main.
-const options = AppState.getOptions();
+const options = Options_.compute(process.argv);
 
 // TODO(@lishaduck): Move to aforementioned `setup` function.
 process.on('uncaughtException', errorHandler);

--- a/lib/new-package.js
+++ b/lib/new-package.js
@@ -214,28 +214,28 @@ async function createProject(
     await FS.mkdirp(path.join(dir, 'tests', ruleNameFolder));
   } catch {}
 
-  Spinner.setText('Adding elm.json');
+  Spinner.setText('Adding elm.json', options.report, options.forTests);
   const packageElmJson = elmJson(authorName, packageName, ruleName, license);
   await writeFile(dir, 'elm.json', JSON.stringify(packageElmJson, null, 4));
 
-  Spinner.succeedAndNowDo('Adding package.json');
+  Spinner.succeedAndNowDo('Adding package.json', options.report);
   await writeFile(
     dir,
     'package.json',
     JSON.stringify(packageJson(options, packageName), null, 2)
   );
 
-  Spinner.succeedAndNowDo('Adding elm-tooling.json');
+  Spinner.succeedAndNowDo('Adding elm-tooling.json', options.report);
   await writeFile(
     dir,
     'elm-tooling.json',
     JSON.stringify(elmToolingJson, null, 4)
   );
 
-  Spinner.succeedAndNowDo('Adding README');
+  Spinner.succeedAndNowDo('Adding README', options.report);
   await writeFile(dir, 'README.md', readme(authorName, packageName, ruleName));
 
-  Spinner.succeedAndNowDo('Adding preview folder');
+  Spinner.succeedAndNowDo('Adding preview folder', options.report);
   const pathToPreview = path.join(process.cwd(), packageName, 'preview');
   await Init.create(options, pathToPreview, 'ReviewConfigForExample.elm');
 
@@ -264,7 +264,7 @@ async function createProject(
     previewReviewConfig.replace(/RULENAME_TO_REPLACE/g, ruleName)
   );
 
-  Spinner.succeedAndNowDo(`Adding rule - ${ruleName}`);
+  Spinner.succeedAndNowDo(`Adding rule - ${ruleName}`, options.report);
 
   await writeFile(
     dir,
@@ -277,7 +277,7 @@ async function createProject(
     NewRule.newTestFile(ruleName)
   );
 
-  Spinner.succeedAndNowDo('Adding .gitignore');
+  Spinner.succeedAndNowDo('Adding .gitignore', options.report);
   await writeFile(
     dir,
     '.gitignore',
@@ -290,7 +290,7 @@ ElmjutsuDumMyM0DuL3.elm
 `
   );
 
-  Spinner.succeedAndNowDo('Adding GitHub Actions');
+  Spinner.succeedAndNowDo('Adding GitHub Actions', options.report);
   const githubDestFiles = path.join(dir, '.github/');
   await Promise.all([
     FS.mkdirp(path.join(githubDestFiles, 'ISSUE_TEMPLATE')),
@@ -303,7 +303,8 @@ ElmjutsuDumMyM0DuL3.elm
   );
 
   Spinner.succeedAndNowDo(
-    `Adding LICENSE ${chalk.grey(`npx license ${license}`)}`
+    `Adding LICENSE ${chalk.grey(`npx license ${license}`)}`,
+    options.report
   );
   const licenseArgs = options.forTests ? '--name "Test User" --year 2020' : '';
   try {
@@ -324,7 +325,7 @@ ElmjutsuDumMyM0DuL3.elm
     }
   }
 
-  Spinner.succeedAndNowDo('Adding elm-review configuration');
+  Spinner.succeedAndNowDo('Adding elm-review configuration', options.report);
   await Init.createFromTemplate(
     options,
     {
@@ -335,7 +336,7 @@ ElmjutsuDumMyM0DuL3.elm
     path.join(process.cwd(), packageName, 'review')
   );
 
-  Spinner.succeedAndNowDo('Adding maintenance scripts');
+  Spinner.succeedAndNowDo('Adding maintenance scripts', options.report);
   const maintenancePath = path.join(process.cwd(), packageName, 'maintenance');
   await FS.mkdirp(maintenancePath);
   await FS.copyFiles(
@@ -369,7 +370,7 @@ ElmjutsuDumMyM0DuL3.elm
   const result = data.replace(/\/\/ @ts-ignore - Generated file.\n/, '');
   await FS.writeFile(checkPreviewsCompile, result, 'utf8');
 
-  Spinner.succeed();
+  Spinner.succeed(undefined, options.report);
 }
 
 /**

--- a/lib/remote-template.js
+++ b/lib/remote-template.js
@@ -33,7 +33,7 @@ async function getRelevantCommit(options, template) {
   }
 
   const defaultBranch = await findDefaultBranch(options, template);
-  Debug.log(`Default branch is: ${defaultBranch}`);
+  Debug.log(`Default branch is: ${defaultBranch}`, options.debug);
   return await getLatestCommitForReference(options, template, defaultBranch);
 }
 
@@ -43,7 +43,7 @@ async function getRelevantCommit(options, template) {
  * @param {Template} template
  */
 async function findDefaultBranch(options, template) {
-  Debug.log('Fetching default branch');
+  Debug.log('Fetching default branch', options.debug);
   const body = /** @type {{default_branch: string}} */ (
     await makeGitHubApiRequest(
       options,
@@ -61,7 +61,7 @@ async function findDefaultBranch(options, template) {
  * @param {string} reference
  */
 async function getLatestCommitForReference(options, template, reference) {
-  Debug.log(`Fetching commit ${reference}`);
+  Debug.log(`Fetching commit ${reference}`, options.debug);
   const body = /** @type {{sha: string}} */ (
     await makeGitHubApiRequest(
       options,
@@ -375,7 +375,7 @@ async function makeGitHubApiRequest(options, url, handleNotFound) {
     }
   };
 
-  Debug.log(`Making API request to GitHub: ${url}`);
+  Debug.log(`Making API request to GitHub: ${url}`, options.debug);
   try {
     // TODO(@lishaduck) [engine:node@>=21]: We can use `fetch` now.
     const response = await got(url, parameters);
@@ -385,10 +385,16 @@ async function makeGitHubApiRequest(options, url, handleNotFound) {
 
     return body;
   } catch (error) {
-    Debug.log(`An error occurred when making a request to the GitHub API:`);
-    Debug.log(`# url: ${url}`);
-    Debug.log(`# statusCode: ${error.response.statusCode}`);
-    Debug.log(`# body:\n${JSON.stringify(error.response.body, null, 4)}`);
+    Debug.log(
+      `An error occurred when making a request to the GitHub API:`,
+      options.debug
+    );
+    Debug.log(`# url: ${url}`, options.debug);
+    Debug.log(`# statusCode: ${error.response.statusCode}`, options.debug);
+    Debug.log(
+      `# body:\n${JSON.stringify(error.response.body, null, 4)}`,
+      options.debug
+    );
     if (error.name === 'HTTPError') {
       switch (error.response.statusCode) {
         case 429:

--- a/lib/result-cache.js
+++ b/lib/result-cache.js
@@ -84,12 +84,13 @@ async function load(options, ignoredDirs, ignoredFiles, cacheFolder) {
         cacheEntry,
         cacheKey
       });
-      Debug.log(`Cached results of ${cacheKey}`);
+      Debug.log(`Cached results of ${cacheKey}`, options.debug);
     } catch (err) {
       const error = intoError(err);
 
       Debug.log(
-        `Error while trying to save results for ${cacheKey}:\n${error.toString()}`
+        `Error while trying to save results for ${cacheKey}:\n${error.toString()}`,
+        options.debug
       );
     } finally {
       AppState.writingToFileSystemCacheFinished(cacheKey);
@@ -116,7 +117,10 @@ async function load(options, ignoredDirs, ignoredFiles, cacheFolder) {
         );
         resultCache.set(name.slice(0, -5), entry);
       } catch {
-        Debug.log(`Ignoring results cache for ${name} as it could not be read`);
+        Debug.log(
+          `Ignoring results cache for ${name} as it could not be read`,
+          options.debug
+        );
       }
     })
   );

--- a/lib/spinner.js
+++ b/lib/spinner.js
@@ -1,11 +1,7 @@
 /**
- * @import {Options} from './types/options';
+ * @import {ReportMode} from './types/options';
  */
 const ora = require('ora');
-const AppState = require('./state');
-
-/** @type {Options} */
-const options = AppState.getOptions();
 
 /**
  * @type {ora.Ora | null}
@@ -16,23 +12,30 @@ let spinner;
  * Set the text of the spinner.
  *
  * @param {string} text
+ * @param {ReportMode} reportFormat
+ * @param {boolean} forTests
  * @returns {void}
  */
-function setText(text) {
+function setText(text, reportFormat, forTests) {
+  if (reportFormat === 'json') return;
+
   if (spinner) {
     spinner.text = text;
   } else {
-    spinner = ora({text, isEnabled: !options.forTests}).start();
+    spinner = ora({text, isEnabled: !forTests}).start();
   }
 }
 
 /**
  * Completes the current task and replaces its text with the given text.
  *
- * @param {string | undefined} [text]
+ * @param {string | undefined} text
+ * @param {ReportMode} reportFormat
  * @returns {void}
  */
-function succeed(text) {
+function succeed(text, reportFormat) {
+  if (reportFormat === 'json') return;
+
   if (!spinner) {
     return;
   }
@@ -45,9 +48,12 @@ function succeed(text) {
  * Completes the current task, and starts a new one with the given text.
  *
  * @param {string} text
+ * @param {ReportMode} reportFormat
  * @returns {void}
  */
-function succeedAndNowDo(text) {
+function succeedAndNowDo(text, reportFormat) {
+  if (reportFormat === 'json') return;
+
   if (!spinner) {
     return;
   }
@@ -59,10 +65,13 @@ function succeedAndNowDo(text) {
 /**
  * Fails the current task and replaces its text with the given text.
  *
- * @param {string | undefined} [text]
+ * @param {string | undefined} text
+ * @param {ReportMode} reportFormat
  * @returns {void}
  */
-function fail(text) {
+function fail(text, reportFormat) {
+  if (reportFormat === 'json') return;
+
   if (!spinner) {
     return;
   }
@@ -71,18 +80,9 @@ function fail(text) {
   spinner = null;
 }
 
-/**
- * @template {(v: string) => void} T
- * @param {T} func
- * @returns {(T | (() => void))}
- */
-function exportFunc(func) {
-  return options.report === 'json' ? () => {} : func;
-}
-
 module.exports = {
-  setText: exportFunc(setText),
-  succeed: exportFunc(succeed),
-  succeedAndNowDo: exportFunc(succeedAndNowDo),
-  fail: exportFunc(fail)
+  setText: setText,
+  succeed: succeed,
+  succeedAndNowDo: succeedAndNowDo,
+  fail: fail
 };

--- a/lib/state.js
+++ b/lib/state.js
@@ -6,15 +6,8 @@
  * @import {Model, Msg} from './types/state';
  * @import {FileId, FilesProposedByCurrentFix} from './types/state';
  * @import {ElmFile, Readme} from './types/content';
- * @import {Options} from './types/options';
  */
 const exit = require('../vendor/exit');
-const options_ = require('./options');
-
-/**
- * @type {Options}
- */
-const options = options_.compute(process.argv);
 
 // MODEL
 
@@ -203,12 +196,6 @@ function updateFilesInCache(files) {
 }
 
 // ACCESS
-
-/** @returns {Options} */
-function getOptions() {
-  return options;
-}
-
 /**
  * @param {Path} filePath
  * @returns {ElmFile | undefined}
@@ -389,7 +376,6 @@ function fixWasRefused() {
 
 module.exports = {
   // ACCESS
-  getOptions,
   getFileFromMemoryCache,
   filesProposedByCurrentFix,
 

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -97,7 +97,10 @@ function watchFiles(
 
           // TODO(@jfmengels): Detect what has changed and only re-load the necessary parts.
           //   We do some of this work in `autofix.js` already.
-          Debug.log('Your `elm.json` has changed. Restarting elm-review.');
+          Debug.log(
+            'Your `elm.json` has changed. Restarting elm-review.',
+            options.debug
+          );
         }
 
         rebuildAndRewatch();
@@ -226,7 +229,7 @@ function createReadmeWatcher(options, app, runReview, onError) {
       disableGlobbing: true
     })
     .on('add', async () => {
-      Debug.log('README.md has been added');
+      Debug.log('README.md has been added', options.debug);
 
       const readme = {
         path: options.readmePath,
@@ -244,7 +247,7 @@ function createReadmeWatcher(options, app, runReview, onError) {
       };
       const readmeHasChanged = AppState.readmeChanged(readme);
       if (readmeHasChanged) {
-        Debug.log('README.md has been changed');
+        Debug.log('README.md has been changed', options.debug);
 
         app.ports.collectReadme.send(readme);
       }
@@ -297,7 +300,10 @@ function createFileWatcher(
         path.relative(process.cwd(), absolutePath)
       );
 
-      Debug.log(`File ${Anonymize.path(options, relativePath)} has been added`);
+      Debug.log(
+        `File ${Anonymize.path(options, relativePath)} has been added`,
+        options.debug
+      );
 
       let elmFile = AppState.getFileFromMemoryCache(relativePath);
 
@@ -342,7 +348,8 @@ function createFileWatcher(
 
       if (hasChanged) {
         Debug.log(
-          `File ${Anonymize.path(options, relativePath)} has been changed`
+          `File ${Anonymize.path(options, relativePath)} has been changed`,
+          options.debug
         );
 
         // NOTE: Mutates the file cache
@@ -360,7 +367,8 @@ function createFileWatcher(
         path.relative(process.cwd(), absolutePath)
       );
       Debug.log(
-        `File ${Anonymize.path(options, relativePath)} has been removed`
+        `File ${Anonymize.path(options, relativePath)} has been removed`,
+        options.debug
       );
 
       app.ports.removeFile.send(relativePath);
@@ -398,7 +406,8 @@ function createExtraFilesWatcher(options, app, runReview, onError, request) {
 
       const newSource = await FS.readFile(relativePath);
       Debug.log(
-        `Extra file ${Anonymize.path(options, relativePath)} has been added`
+        `Extra file ${Anonymize.path(options, relativePath)} has been added`,
+        options.debug
       );
 
       app.ports.collectExtraFiles.send({[relativePath]: newSource});
@@ -411,7 +420,8 @@ function createExtraFilesWatcher(options, app, runReview, onError, request) {
 
       const newSource = await FS.readFile(relativePath);
       Debug.log(
-        `Extra file ${Anonymize.path(options, relativePath)} has been changed`
+        `Extra file ${Anonymize.path(options, relativePath)} has been changed`,
+        options.debug
       );
 
       app.ports.collectExtraFiles.send({[relativePath]: newSource});
@@ -422,7 +432,8 @@ function createExtraFilesWatcher(options, app, runReview, onError, request) {
         path.relative(process.cwd(), absolutePath)
       );
       Debug.log(
-        `Extra file ${Anonymize.path(options, relativePath)} has been removed`
+        `Extra file ${Anonymize.path(options, relativePath)} has been removed`,
+        options.debug
       );
 
       app.ports.removeFile.send(relativePath);
@@ -455,7 +466,7 @@ function createSuppressedFilesWatcher(options, app, onError) {
       const suppressedErrors = await SuppressedErrors.read(options);
       // TODO(@jfmengels): Avoid doing anything if suppressed errors haven't
       //   changed. It's likely this program's fault for changing anything anyway.
-      Debug.log('Suppressed errors have been added');
+      Debug.log('Suppressed errors have been added', options.debug);
       app.ports.updateSuppressedErrors.send(suppressedErrors);
     }, 20);
   }


### PR DESCRIPTION
In order for the next refactor to work, they must be created on-demand.