### PR TITLE
refactor: centralize into functions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,19 +1,8 @@
-// TODO(@lishaduck): Create a `setup` function.
-process.title = 'elm-review';
-
-if (!process.argv.includes('--no-color')) {
-  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') {
-    process.argv.push('--no-color');
-  } else {
-    // Force `chalk` to add colors by default.
-    process.argv.push('--color');
-  }
-}
-
 /**
  * @import {Options, ReviewOptions} from './types/options';
  */
 const path = require('node:path');
+const process = require('node:process');
 const chalk = require('chalk');
 const exit = require('../vendor/exit');
 const Anonymize = require('./anonymize');
@@ -34,44 +23,66 @@ const SuppressedErrors = require('./suppressed-errors');
 const Watch = require('./watch');
 
 /**
- * @type {Options}
+ * @param {NodeJS.Process} process
+ * @typedef {(err: Error) => never} ErrorHandler
  */
-const options = Options_.compute(process.argv);
 
-// TODO(@lishaduck): Move to aforementioned `setup` function.
-process.on('uncaughtException', errorHandler);
-process.on('unhandledRejection', errorHandler);
+function setup(process) {
+  process.title = 'elm-review';
+
+  if (!process.argv.includes('--no-color')) {
+    if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') {
+      process.argv.push('--no-color');
+    } else {
+      // Force `chalk` to add colors by default.
+      process.argv.push('--color');
+    }
+  }
+
+  const options = Options_.compute(process.argv);
+
+  const errorHandler = errorHandlerFactory(options);
+
+  process.on('uncaughtException', errorHandler);
+  process.on('unhandledRejection', errorHandler);
+
+  return {options, errorHandler};
+}
 
 /**
  * Exit the process with status code 1 after printing an error message.
  *
- * @param {Error} err - An error object.
- * @returns {never}
+ * @param {Options} options - An error object.
+ * @returns {ErrorHandler}
  */
-function errorHandler(err) {
-  Spinner.fail(undefined, options.report);
-  let userSrc = null;
-  try {
-    userSrc = options.userSrc();
-  } catch {
-    userSrc = process.cwd();
-  }
+function errorHandlerFactory(options) {
+  return (err) => {
+    Spinner.fail(undefined, options.report);
 
-  const reviewElmJsonPath = path.join(userSrc, 'elm.json');
+    let userSrc = null;
+    try {
+      userSrc = options.userSrc();
+    } catch {
+      userSrc = process.cwd();
+    }
 
-  const errorToReport =
-    err instanceof ErrorMessage.CustomError
-      ? err
-      : ErrorMessage.unexpectedError(err);
-  console.log(ErrorMessage.report(options, errorToReport, reviewElmJsonPath));
+    const reviewElmJsonPath = path.join(userSrc, 'elm.json');
 
-  exit(1);
+    const errorToReport =
+      err instanceof ErrorMessage.CustomError
+        ? err
+        : ErrorMessage.unexpectedError(err);
+    console.log(ErrorMessage.report(options, errorToReport, reviewElmJsonPath));
+
+    exit(1);
+  };
 }
 
 /**
+ * @param {Options} options
  * @returns {Promise<void>}
  */
-async function runElmReview() {
+async function runElmReview(options) {
   const {elmModulePath, reviewElmJson, appHash} = await Builder.build(options);
 
   if (!elmModulePath) {
@@ -102,9 +113,11 @@ async function runElmReview() {
 }
 
 /**
+ * @param {Options} options
+ * @param {ErrorHandler} errorHandler
  * @returns {Promise<void | never>}
  */
-async function runElmReviewInWatchMode() {
+async function runElmReviewInWatchMode(options, errorHandler) {
   AppWrapper.stop();
   const {elmModulePath, reviewElmJson, reviewElmJsonPath, appHash} =
     await Builder.build(options);
@@ -118,7 +131,7 @@ async function runElmReviewInWatchMode() {
       reviewElmJsonPath,
       () => {
         AppState.buildRestarted();
-        void runElmReviewInWatchMode();
+        void runElmReviewInWatchMode(options, errorHandler);
       }
     );
     return;
@@ -135,7 +148,7 @@ async function runElmReviewInWatchMode() {
     {...initialization, reviewElmJson, reviewElmJsonPath},
     () => {
       AppState.buildRestarted();
-      void runElmReviewInWatchMode();
+      void runElmReviewInWatchMode(options, errorHandler);
     },
     errorHandler
   );
@@ -148,9 +161,10 @@ async function runElmReviewInWatchMode() {
 }
 
 /**
+ * @param {Options} options
  * @returns {Promise<void>}
  */
-async function prepareOffline() {
+async function prepareOffline(options) {
   const elmBinary = await ElmBinary.getElmBinary(options);
   ElmBinary.downloadDependenciesOfElmJson(
     elmBinary,
@@ -178,9 +192,20 @@ if either your review configuration or your project's dependencies change.`);
 }
 
 /**
- * @returns {Promise<void | never>}
+ * @returns {Promise<void>}
  */
 async function main() {
+  const {options, errorHandler} = setup(process);
+
+  await app(options, errorHandler);
+}
+
+/**
+ * @param {Options} options
+ * @param {ErrorHandler} errorHandler
+ * @returns {Promise<void>}
+ */
+async function app(options, errorHandler) {
   if (options.version) {
     console.log(Anonymize.version(options));
     return;
@@ -249,7 +274,7 @@ async function main() {
         return;
       }
 
-      await prepareOffline();
+      await prepareOffline(options);
       return;
     }
 
@@ -261,7 +286,7 @@ async function main() {
 
       if (options.watch) {
         try {
-          await runElmReviewInWatchMode();
+          await runElmReviewInWatchMode(options, errorHandler);
           return;
         } catch (error) {
           errorHandler(error);
@@ -271,7 +296,7 @@ async function main() {
   }
 
   try {
-    await runElmReview();
+    await runElmReview(options);
   } catch (error) {
     errorHandler(error);
   }


### PR DESCRIPTION
Stop running stuff on module evaluation, instead run it on executing `main()`.

Depends on #380.