### PR TITLE
Refactor `process.cwd` calls

### DIFF
--- a/lib/anonymize.js
+++ b/lib/anonymize.js
@@ -37,7 +37,7 @@ function pathsAndVersions(options, string) {
  */
 function anonymizePath(options, filePath) {
   if (options.forTests) {
-    return replaceVersion(path.relative(process.cwd(), filePath));
+    return replaceVersion(path.relative(options.cwd, filePath));
   }
 
   return filePath;

--- a/lib/autofix.js
+++ b/lib/autofix.js
@@ -196,7 +196,7 @@ function formatFileContent(options, file, filePath) {
       input: file.source,
       env: {
         ...process.env,
-        [pathKey]: backwardsCompatiblePath(options.elmFormatPath)
+        [pathKey]: backwardsCompatiblePath(options.elmFormatPath, options.cwd)
       }
     }
   );

--- a/lib/build.js
+++ b/lib/build.js
@@ -366,7 +366,7 @@ function updateSourceDirectories(options, userSrc, elmJson) {
   if (options.localElmReviewSrc) {
     sourceDirectories = unique([
       ...sourceDirectories,
-      path.resolve(process.cwd(), options.localElmReviewSrc)
+      path.resolve(options.cwd, options.localElmReviewSrc)
     ]);
   }
 

--- a/lib/elm-binary.js
+++ b/lib/elm-binary.js
@@ -19,7 +19,7 @@ const {backwardsCompatiblePath} = require('./npx');
 async function getElmBinary(options) {
   try {
     const elmBinaryPath = await which(options.compiler ?? 'elm', {
-      path: backwardsCompatiblePath(options.compiler)
+      path: backwardsCompatiblePath(options.compiler, options.cwd)
     });
     return path.resolve(elmBinaryPath);
   } catch {

--- a/lib/elm-files.js
+++ b/lib/elm-files.js
@@ -244,7 +244,7 @@ function getSourceDirectories(options, elmJson) {
       isFromCliArguments: true,
       sourceDirectories: unique(
         options.directoriesToAnalyze.map((directory) =>
-          path.resolve(process.cwd(), directory)
+          path.resolve(options.cwd, directory)
         )
       )
     };

--- a/lib/main.js
+++ b/lib/main.js
@@ -39,7 +39,7 @@ function setup(process) {
     }
   }
 
-  const options = Options_.compute(process.argv);
+  const options = Options_.compute(process.argv, process.cwd());
 
   const errorHandler = errorHandlerFactory(options);
 
@@ -63,7 +63,7 @@ function errorHandlerFactory(options) {
     try {
       userSrc = options.userSrc();
     } catch {
-      userSrc = process.cwd();
+      userSrc = options.cwd;
     }
 
     const reviewElmJsonPath = path.join(userSrc, 'elm.json');

--- a/lib/new-package.js
+++ b/lib/new-package.js
@@ -203,7 +203,7 @@ async function createProject(
   ruleType,
   license
 ) {
-  const dir = path.join(process.cwd(), packageName);
+  const dir = path.join(options.cwd, packageName);
   const ruleNameFolder = ruleName.split('.').slice(0, -1).join('/');
 
   try {
@@ -236,7 +236,7 @@ async function createProject(
   await writeFile(dir, 'README.md', readme(authorName, packageName, ruleName));
 
   Spinner.succeedAndNowDo('Adding preview folder', options.report);
-  const pathToPreview = path.join(process.cwd(), packageName, 'preview');
+  const pathToPreview = path.join(options.cwd, packageName, 'preview');
   await Init.create(options, pathToPreview, 'ReviewConfigForExample.elm');
 
   // Adding package to the example's elm.json
@@ -333,11 +333,11 @@ ElmjutsuDumMyM0DuL3.elm
       pathToFolder: 'new-package/review-config-templates/2.3.0',
       reference: null
     },
-    path.join(process.cwd(), packageName, 'review')
+    path.join(options.cwd, packageName, 'review')
   );
 
   Spinner.succeedAndNowDo('Adding maintenance scripts', options.report);
-  const maintenancePath = path.join(process.cwd(), packageName, 'maintenance');
+  const maintenancePath = path.join(options.cwd, packageName, 'maintenance');
   await FS.mkdirp(maintenancePath);
   await FS.copyFiles(
     path.join(__dirname, '../new-package/maintenance/'),
@@ -346,7 +346,7 @@ ElmjutsuDumMyM0DuL3.elm
   );
 
   const packageTests = path.join(
-    process.cwd(),
+    options.cwd,
     packageName,
     'elm-review-package-tests'
   );

--- a/lib/npx.js
+++ b/lib/npx.js
@@ -62,12 +62,12 @@ const pathKey = getPathKey();
  * This can be removed in a major version.
  *
  * @param {Path | undefined} providedBinaryPath
+ * @param {string} cwd
  * @returns {Path}
  */
-function backwardsCompatiblePath(providedBinaryPath) {
+function backwardsCompatiblePath(providedBinaryPath, cwd) {
   return [
-    ...process
-      .cwd()
+    ...cwd
       .split(path.sep)
       .map((_, index, parts) =>
         [...parts.slice(0, index + 1), 'node_modules', '.bin'].join(path.sep)

--- a/lib/options.js
+++ b/lib/options.js
@@ -42,10 +42,11 @@ let containsHelp = false;
 /**
  * Compute the options for this run.
  *
- * @param {string[]} processArgv
+ * @param {string[]} processArgv - An argument array (typically `process.argv`)
+ * @param {Path} cwd - The current working directory (typically `process.cwd()`)
  * @returns {Options | never}
  */
-function compute(processArgv) {
+function compute(processArgv, cwd) {
   containsHelp =
     processArgv.slice(2).includes('--help') ||
     processArgv.slice(2).includes('-h');
@@ -79,7 +80,7 @@ function compute(processArgv) {
   }
 
   /** @type {Path | null} */
-  const elmJsonPath = findElmJsonPath(args, subcommand);
+  const elmJsonPath = findElmJsonPath(args, subcommand, cwd);
   /** @type {Path | null} */
   const readmePath =
     elmJsonPath && path.join(path.dirname(elmJsonPath), 'README.md');
@@ -89,13 +90,13 @@ function compute(processArgv) {
    */
   function initPath() {
     if (args.config) {
-      return path.resolve(process.cwd(), args.config);
+      return path.resolve(cwd, args.config);
     }
 
     try {
       return path.join(projectToReview(), 'review');
     } catch {
-      return path.join(process.cwd(), 'review');
+      return path.join(cwd, 'review');
     }
   }
 
@@ -111,7 +112,7 @@ function compute(processArgv) {
 
 If you wish to run elm-review from outside your project,
 try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
-        path.relative(process.cwd(), 'elm.json')
+        path.relative(cwd, 'elm.json')
       );
     }
 
@@ -163,7 +164,7 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
    */
   function userSrc() {
     return args.config
-      ? path.resolve(process.cwd(), args.config)
+      ? path.resolve(cwd, args.config)
       : path.join(projectToReview(), 'review');
   }
 
@@ -258,7 +259,7 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
       : null,
 
     // PATHS - REVIEW APPLICATION
-
+    cwd,
     userSrc,
     usedConfig: Boolean(args.config),
     template,
@@ -271,7 +272,7 @@ try re-running it with ${chalk.cyan('--elmjson <path-to-elm.json>')}.`,
       path.join(elmStuffFolder(), 'review-applications', `${appHash}.js`),
     elmParserPath: (elmSyntaxVersion) =>
       path.resolve(
-        process.cwd(),
+        cwd,
         elmStuffFolder(),
         'elm-parser',
         `elm-syntax-v${elmSyntaxVersion}${args.debug ? '-debug' : ''}.js`
@@ -391,9 +392,10 @@ ${Flags.buildFlag(subcommand, Flags.templateFlag)}`
 /**
  * @param {ParsedArgs} args
  * @param {Subcommand | null} subcommand
+ * @param {Path} cwd
  * @returns {Path | null}
  */
-function findElmJsonPath(args, subcommand) {
+function findElmJsonPath(args, subcommand, cwd) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Casting is ugly.
   if (args.elmjson) return args.elmjson;
   // Shortcutting the search for elm.json when `--help` since we won't need it
@@ -409,7 +411,7 @@ function findElmJsonPath(args, subcommand) {
     return null;
   }
 
-  return findUp.sync('elm.json') ?? null;
+  return findUp.sync('elm.json', {cwd}) ?? null;
 }
 
 /**

--- a/lib/run-review.js
+++ b/lib/run-review.js
@@ -36,7 +36,7 @@ async function runReview(options, app) {
       const orange = chalk.keyword('orange');
       console.log(
         `I created suppressions files in ${orange(
-          path.relative(process.cwd(), options.suppressedErrorsFolder())
+          path.relative(options.cwd, options.suppressedErrorsFolder())
         )}`
       );
     }

--- a/lib/suppressed-errors.js
+++ b/lib/suppressed-errors.js
@@ -52,9 +52,8 @@ async function write(options, suppressionFiles) {
           const error = intoError(err);
 
           const relativeFolderPath =
-            path.relative(process.cwd(), options.suppressedErrorsFolder()) +
-            '/';
-          const relativeFilePath = path.relative(process.cwd(), filePath);
+            path.relative(options.cwd, options.suppressedErrorsFolder()) + '/';
+          const relativeFilePath = path.relative(options.cwd, filePath);
           throw new ErrorMessage.CustomError(
             'FAILED TO UPDATE SUPPRESSION FILE',
             // prettier-ignore
@@ -181,7 +180,7 @@ Try updating ${chalk.greenBright('elm-review')} to a version that supports this 
  */
 function checkForUncommittedSuppressions(options) {
   const pathToSuppressedFolder = path.relative(
-    process.cwd(),
+    options.cwd,
     options.suppressedErrorsFolder()
   );
 

--- a/lib/types/options.ts
+++ b/lib/types/options.ts
@@ -43,6 +43,7 @@ export type Options = OptionsBase & {
   newRuleName: string | null;
   ruleType: RuleType | undefined;
 
+  cwd: Path;
   userSrc: () => Path;
   usedConfig: boolean;
   template: Template | null;

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -297,7 +297,7 @@ function createFileWatcher(
     )
     .on('add', async (absolutePath) => {
       const relativePath = OsHelpers.makePathOsAgnostic(
-        path.relative(process.cwd(), absolutePath)
+        path.relative(options.cwd, absolutePath)
       );
 
       Debug.log(
@@ -334,7 +334,7 @@ function createFileWatcher(
     })
     .on('change', async (absolutePath) => {
       const relativePath = OsHelpers.makePathOsAgnostic(
-        path.relative(process.cwd(), absolutePath)
+        path.relative(options.cwd, absolutePath)
       );
 
       const elmFile = AppState.getFileFromMemoryCache(relativePath) ?? {
@@ -364,7 +364,7 @@ function createFileWatcher(
     })
     .on('unlink', (absolutePath) => {
       const relativePath = OsHelpers.makePathOsAgnostic(
-        path.relative(process.cwd(), absolutePath)
+        path.relative(options.cwd, absolutePath)
       );
       Debug.log(
         `File ${Anonymize.path(options, relativePath)} has been removed`,
@@ -401,7 +401,7 @@ function createExtraFilesWatcher(options, app, runReview, onError, request) {
     )
     .on('add', async (absolutePath) => {
       const relativePath = OsHelpers.makePathOsAgnostic(
-        path.relative(process.cwd(), absolutePath)
+        path.relative(options.cwd, absolutePath)
       );
 
       const newSource = await FS.readFile(relativePath);
@@ -415,7 +415,7 @@ function createExtraFilesWatcher(options, app, runReview, onError, request) {
     })
     .on('change', async (absolutePath) => {
       const relativePath = OsHelpers.makePathOsAgnostic(
-        path.relative(process.cwd(), absolutePath)
+        path.relative(options.cwd, absolutePath)
       );
 
       const newSource = await FS.readFile(relativePath);
@@ -429,7 +429,7 @@ function createExtraFilesWatcher(options, app, runReview, onError, request) {
     })
     .on('unlink', (absolutePath) => {
       const relativePath = OsHelpers.makePathOsAgnostic(
-        path.relative(process.cwd(), absolutePath)
+        path.relative(options.cwd, absolutePath)
       );
       Debug.log(
         `Extra file ${Anonymize.path(options, relativePath)} has been removed`,


### PR DESCRIPTION
I do think it'd be good to audit usages of cwd at some point.
A few of these feel like they don't actually need the cwd.

This is good bandaid for now though.